### PR TITLE
Disable unavailable version filters

### DIFF
--- a/frontend/src/AddEntry.css
+++ b/frontend/src/AddEntry.css
@@ -139,6 +139,10 @@ select {
   border-color: var(--color-purple-primary);
   color: var(--color-bg-page);
 }
+.chip:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
 .version-table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/AddEntry.jsx
+++ b/frontend/src/AddEntry.jsx
@@ -151,6 +151,7 @@ export default function AddEntry({ onAdded, editingMod, onEditDone }) {
       .sort((a,b) => new Date(b.date_published || b.date || 0) - new Date(a.date_published || a.date || 0));
     setVersionOptions(versions);
     setSelectedVersion(versions[0] || null);
+    setChannelFilter(versions[0]?.version_type || '');
   }
 
   function selectVersion(v) {
@@ -313,6 +314,7 @@ export default function AddEntry({ onAdded, editingMod, onEditDone }) {
                     key={c}
                     className={`chip ${channelFilter === c ? 'active' : ''}`}
                     onClick={() => setChannelFilter(c)}
+                    disabled={!versionOptions.some(v => v.version_type === c)}
                   >
                     {c[0].toUpperCase() + c.slice(1)}
                   </button>


### PR DESCRIPTION
## Summary
- disable version filter chips when no versions are available
- default mod version filter to the first available channel
- add styles for disabled chips

## Testing
- `npm run build -- --outDir temp-dist`


------
https://chatgpt.com/codex/tasks/task_e_68a420ffec088321b1dd876f6c266475