### PR TITLE
Add placeholder dist assets and expose helpers for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 frontend/node_modules
-frontend/dist/
+frontend/dist/*
+!frontend/dist/index.html
 mods.db

--- a/db_helpers.go
+++ b/db_helpers.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"database/sql"
+
+	dbpkg "modsentinel/internal/db"
+)
+
+type Mod = dbpkg.Mod
+
+func initDB(db *sql.DB) error { return dbpkg.Init(db) }
+
+func insertMod(db *sql.DB, m *Mod) error { return dbpkg.InsertMod(db, m) }
+
+func updateMod(db *sql.DB, m *Mod) error { return dbpkg.UpdateMod(db, m) }
+
+func deleteMod(db *sql.DB, id int) error { return dbpkg.DeleteMod(db, id) }
+
+func listMods(db *sql.DB) ([]Mod, error) { return dbpkg.ListMods(db) }

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ModSentinel</title>
+</head>
+<body>
+  <p>Placeholder build output.</p>
+</body>
+</html>

--- a/slug.go
+++ b/slug.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"errors"
+	urlpkg "net/url"
+	"strings"
+)
+
+func parseModrinthSlug(raw string) (string, error) {
+	u, err := urlpkg.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(u.Path, "/")
+	for i, p := range parts {
+		if p == "mod" || p == "plugin" || p == "datapack" || p == "resourcepack" {
+			if i+1 < len(parts) {
+				return parts[i+1], nil
+			}
+		}
+	}
+	return "", errors.New("slug not found")
+}


### PR DESCRIPTION
## Summary
- allow embedding to succeed by tracking a placeholder `frontend/dist/index.html`
- add db and slug helper functions so tests can call internal logic

## Testing
- `npm run build`
- `go vet -v ./...`
- `go build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a43260ab9083218e0d05dd436e0d55