### PR TITLE
Add app error boundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,48 @@
+import { Component } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function ErrorFallback({ onRetry }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-sm text-center">
+      <h1 className="text-xl font-semibold">Something went wrong.</h1>
+      <button
+        onClick={() => {
+          onRetry();
+          navigate(0);
+        }}
+        className="rounded bg-primary px-md py-sm text-primary-foreground"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Error boundary caught an error', error, errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallback onRetry={this.handleRetry} />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
+import ErrorBoundary from '@/components/ErrorBoundary.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('app')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- handle render crashes with a global error boundary and fallback UI
- wrap app in error boundary so Retry reloads current route

## Testing
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4d96138048321abd17a6bc64c92dd