### PR TITLE
Inline token warning, sidebar hover animations, move Add Mod action, sidebar logo placement, accessibility fixes, and responsive wrap

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Home, Settings, Plus, Package, AlertTriangle } from 'lucide-react';
+import { Home, Settings, Package, AlertTriangle } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils.js';
 import { getToken } from '@/lib/api.ts';
@@ -7,7 +7,7 @@ import { getToken } from '@/lib/api.ts';
 export default function Sidebar({ open, onClose }) {
   const linkClass = ({ isActive }) =>
     cn(
-      'flex items-center gap-sm rounded-md p-sm text-sm font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+      'flex flex-wrap items-center gap-sm md:gap-0 lg:gap-sm rounded-md p-sm text-sm font-medium hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 transition-transform motion-reduce:transition-none motion-safe:hover:translate-x-0.5 motion-safe:focus-visible:translate-x-0.5 justify-start md:justify-center lg:justify-start',
       isActive && 'bg-muted'
     );
   const [hasToken, setHasToken] = useState(true);
@@ -26,40 +26,59 @@ export default function Sidebar({ open, onClose }) {
     <>
       <aside
         className={cn(
-          'fixed inset-y-0 left-0 z-20 w-64 transform bg-muted p-md transition-transform md:static md:translate-x-0',
+          'fixed inset-y-0 left-0 z-20 w-64 md:w-16 lg:w-64 transform bg-muted p-md transition-transform md:static md:translate-x-0',
           open ? 'translate-x-0' : '-translate-x-full'
         )}
       >
+        <NavLink
+          to="/"
+          end
+          onClick={onClose}
+          className="mb-md flex items-center gap-sm md:gap-0 lg:gap-sm rounded-md p-sm justify-start md:justify-center lg:justify-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          aria-label="ModSentinel"
+          title="ModSentinel"
+        >
+          <img src="/favicon.ico" alt="ModSentinel" className="h-6 w-6" />
+          <span className="hidden text-lg font-bold lg:inline">ModSentinel</span>
+        </NavLink>
         <nav className="flex flex-col gap-xs">
-          {!hasToken && (
-            <NavLink
-              to="/settings"
-              onClick={onClose}
-              className="mb-xs inline-flex w-fit items-center gap-xs rounded-full bg-amber-500 px-sm py-xs text-xs font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-            >
-              <AlertTriangle className="h-3 w-3" />
-              Add token
-            </NavLink>
-          )}
-          <NavLink to="/" end className={linkClass} onClick={onClose}>
-            <Home className="h-4 w-4" />
-            Dashboard
-          </NavLink>
-          <NavLink to="/mods" end className={linkClass} onClick={onClose}>
-            <Package className="h-4 w-4" />
-            Mods
+          <NavLink
+            to="/"
+            end
+            className={linkClass}
+            onClick={onClose}
+            aria-label="Dashboard"
+            title="Dashboard"
+          >
+            <Home className="h-4 w-4" aria-hidden="true" />
+            <span className="md:hidden lg:inline">Dashboard</span>
           </NavLink>
           <NavLink
-            to="/mods/add"
-            className={(s) => cn(linkClass(s), !hasToken && 'pointer-events-none opacity-50')}
+            to="/mods"
+            end
+            className={linkClass}
             onClick={onClose}
+            aria-label="Mods"
+            title="Mods"
           >
-            <Plus className="h-4 w-4" />
-            Add Mod
+            <Package className="h-4 w-4" aria-hidden="true" />
+            <span className="md:hidden lg:inline">Mods</span>
           </NavLink>
-          <NavLink to="/settings" className={linkClass} onClick={onClose}>
-            <Settings className="h-4 w-4" />
-            Settings
+          <NavLink
+            to="/settings"
+            className={linkClass}
+            onClick={onClose}
+            aria-label="Settings"
+            title="Settings"
+          >
+            <Settings className="h-4 w-4" aria-hidden="true" />
+            <span className="md:hidden lg:inline">Settings</span>
+            {!hasToken && (
+              <span className="ml-auto inline-flex shrink-0 self-stretch items-center gap-xs rounded-md bg-amber-500 px-sm text-xs font-semibold text-white md:hidden lg:inline-flex">
+                <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                Add token
+              </span>
+            )}
           </NavLink>
         </nav>
       </aside>

--- a/frontend/src/pages/Mods.jsx
+++ b/frontend/src/pages/Mods.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Package, RefreshCw, Trash2 } from 'lucide-react';
+import { useSearchParams, Link } from 'react-router-dom';
+import { Package, RefreshCw, Trash2, Plus } from 'lucide-react';
 import { Input } from '@/components/ui/Input.jsx';
 import { Select } from '@/components/ui/Select.jsx';
 import { Button } from '@/components/ui/Button.jsx';
@@ -15,6 +15,7 @@ import {
 import { Skeleton } from '@/components/ui/Skeleton.jsx';
 import { EmptyState } from '@/components/ui/EmptyState.jsx';
 import { getMods, refreshMod, deleteMod, getToken } from '@/lib/api.ts';
+import { cn } from '@/lib/utils.js';
 import { toast } from 'sonner';
 import { useConfirm } from '@/hooks/useConfirm.jsx';
 
@@ -117,34 +118,48 @@ export default function Mods() {
   return (
     <div className="space-y-md">
       {ConfirmModal}
-      <div className="flex flex-col gap-sm sm:flex-row sm:items-center">
-        <div className="flex flex-col">
-          <label htmlFor="filter" className="sr-only">
-            Filter mods
-          </label>
-          <Input
-            id="filter"
-            placeholder="Filter mods..."
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            className="sm:max-w-xs"
-          />
-        </div>
-        <div className="flex flex-col">
-          <label htmlFor="sort" className="sr-only">
-            Sort mods
-          </label>
-          <Select
-            id="sort"
-            value={sort}
-            onChange={(e) => setSort(e.target.value)}
-            className="sm:w-40"
+        <div className="flex flex-col gap-sm sm:flex-row sm:items-center">
+          <div className="flex flex-col">
+            <label htmlFor="filter" className="sr-only">
+              Filter mods
+            </label>
+            <Input
+              id="filter"
+              placeholder="Filter mods..."
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              className="sm:max-w-xs"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="sort" className="sr-only">
+              Sort mods
+            </label>
+            <Select
+              id="sort"
+              value={sort}
+              onChange={(e) => setSort(e.target.value)}
+              className="sm:w-40"
+            >
+              <option value="name-asc">Name A–Z</option>
+              <option value="name-desc">Name Z–A</option>
+            </Select>
+          </div>
+          <Link
+            to="/mods/add"
+            className={cn(
+              'sm:ml-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+              !hasToken && 'pointer-events-none opacity-50'
+            )}
+            aria-disabled={!hasToken}
+            title="Add Mod"
           >
-            <option value="name-asc">Name A–Z</option>
-            <option value="name-desc">Name Z–A</option>
-          </Select>
+            <Button className="w-full sm:w-auto gap-xs" disabled={!hasToken}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add Mod
+            </Button>
+          </Link>
         </div>
-      </div>
 
       {!hasToken && (
         <p className="text-sm text-muted-foreground">
@@ -240,7 +255,7 @@ export default function Mods() {
                       className="h-8 px-sm"
                       disabled={!hasToken}
                     >
-                      <RefreshCw className="h-4 w-4" />
+                      <RefreshCw className="h-4 w-4" aria-hidden="true" />
                     </Button>
                     <Button
                       variant="outline"
@@ -248,7 +263,7 @@ export default function Mods() {
                       aria-label="Delete mod"
                       className="h-8 px-sm"
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
                     </Button>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
## Summary
- align Add token warning with Settings link and ensure clicking anywhere opens Settings
- add reduced-motion friendly hover animations for sidebar buttons
- move Add Mod action from sidebar to a primary button on the Mods page header
- place responsive ModSentinel logo at the top of the sidebar, showing the wordmark only on expanded screens
- improve sidebar and Mods page accessibility with aria labels, tooltips, and visible focus states
- allow the Add token warning to wrap so the Settings row remains readable on narrow screens

## Testing
- `npm test --prefix frontend`
- `go test ./... | tee /tmp/go-test.log`
- `npm run build --prefix frontend`
- `npx -y @axe-core/cli frontend/dist/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68a4db1029ec832194600324cb812293