### PR TITLE
feat: add instance entity

### DIFF
--- a/db_helpers.go
+++ b/db_helpers.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Mod = dbpkg.Mod
+type Instance = dbpkg.Instance
 
 func initDB(db *sql.DB) error { return dbpkg.Init(db) }
 
@@ -16,4 +17,6 @@ func updateMod(db *sql.DB, m *Mod) error { return dbpkg.UpdateMod(db, m) }
 
 func deleteMod(db *sql.DB, id int) error { return dbpkg.DeleteMod(db, id) }
 
-func listMods(db *sql.DB) ([]Mod, error) { return dbpkg.ListMods(db) }
+func insertInstance(db *sql.DB, inst *Instance) error { return dbpkg.InsertInstance(db, inst) }
+
+func listMods(db *sql.DB, instanceID int) ([]Mod, error) { return dbpkg.ListMods(db, instanceID) }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,17 @@
 import { Suspense, lazy } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import Layout from '@/components/Layout.jsx';
 import DashboardSkeleton from '@/pages/DashboardSkeleton.jsx';
 import ModsSkeleton from '@/pages/ModsSkeleton.jsx';
 import AddModSkeleton from '@/pages/AddModSkeleton.jsx';
 import SettingsSkeleton from '@/pages/SettingsSkeleton.jsx';
+import InstancesSkeleton from '@/pages/InstancesSkeleton.jsx';
 
 const Dashboard = lazy(() => import('@/pages/Dashboard.jsx'));
 const Mods = lazy(() => import('@/pages/Mods.jsx'));
 const AddMod = lazy(() => import('@/pages/AddMod.jsx'));
 const Settings = lazy(() => import('@/pages/Settings.jsx'));
+const Instances = lazy(() => import('@/pages/Instances.jsx'));
 
 export default function App() {
   return (
@@ -24,7 +26,15 @@ export default function App() {
           }
         />
         <Route
-          path="/mods"
+          path="/instances"
+          element={
+            <Suspense fallback={<InstancesSkeleton />}>
+              <Instances />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/instances/:id"
           element={
             <Suspense fallback={<ModsSkeleton />}>
               <Mods />
@@ -32,13 +42,14 @@ export default function App() {
           }
         />
         <Route
-          path="/mods/add"
+          path="/instances/:id/add"
           element={
             <Suspense fallback={<AddModSkeleton />}>
               <AddMod />
             </Suspense>
           }
         />
+        <Route path="/mods/*" element={<Navigate to="/instances" replace />} />
         <Route
           path="/settings"
           element={

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,8 +1,9 @@
 import { Menu, Shield } from 'lucide-react';
+import InstanceSwitcher from './InstanceSwitcher.jsx';
 
 export default function Header({ onMenuClick }) {
   return (
-    <header className="flex items-center gap-sm border-b border-border p-md">
+    <header className="flex flex-wrap items-center gap-sm border-b border-border p-md">
       <button
         className="md:hidden rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         onClick={onMenuClick}
@@ -14,6 +15,7 @@ export default function Header({ onMenuClick }) {
         <Shield className="h-6 w-6" />
         <h1 className="text-xl font-bold">ModSentinel</h1>
       </div>
+      <InstanceSwitcher />
     </header>
   );
 }

--- a/frontend/src/components/InstanceSwitcher.jsx
+++ b/frontend/src/components/InstanceSwitcher.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { useMatch, useNavigate } from 'react-router-dom';
+import { Select } from '@/components/ui/Select.jsx';
+import { getInstances } from '@/lib/api.ts';
+
+export default function InstanceSwitcher() {
+  const [instances, setInstances] = useState([]);
+  const navigate = useNavigate();
+  const match = useMatch('/instances/:id/*');
+  const currentId = match?.params.id ?? '';
+
+  useEffect(() => {
+    async function fetch() {
+      try {
+        const data = await getInstances();
+        setInstances(data);
+      } catch {
+        // ignore errors
+      }
+    }
+    fetch();
+  }, []);
+
+  function handleChange(e) {
+    const id = e.target.value;
+    if (id) {
+      navigate(`/instances/${id}`);
+    }
+  }
+
+  return (
+    <div className="md:ml-auto w-full md:w-48 mt-sm md:mt-0">
+      <label htmlFor="instance-switcher" className="sr-only">
+        Switch instance
+      </label>
+      <Select
+        id="instance-switcher"
+        value={currentId}
+        onChange={handleChange}
+        className="w-full"
+      >
+        <option value="" disabled>
+          Select instance
+        </option>
+        {instances.map((inst) => (
+          <option key={inst.id} value={inst.id}>
+            {inst.name}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}

--- a/frontend/src/components/InstanceSwitcher.test.jsx
+++ b/frontend/src/components/InstanceSwitcher.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+const navigateMock = vi.fn();
+
+vi.mock('@/lib/api.ts', () => ({
+  getInstances: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+import InstanceSwitcher from './InstanceSwitcher.jsx';
+import { getInstances } from '@/lib/api.ts';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('InstanceSwitcher', () => {
+  it('navigates to selected instance', async () => {
+    getInstances.mockResolvedValue([
+      { id: 1, name: 'One' },
+      { id: 2, name: 'Two' },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/instances/1']}>
+        <InstanceSwitcher />
+      </MemoryRouter>
+    );
+
+    const select = await screen.findByLabelText('Switch instance');
+    expect(select.parentElement).toHaveClass('w-full');
+    expect(select.parentElement).toHaveClass('md:w-48');
+    fireEvent.change(select, { target: { value: '2' } });
+    expect(navigateMock).toHaveBeenCalledWith('/instances/2');
+  });
+});

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Home, Settings, Package, AlertTriangle } from 'lucide-react';
+import { Home, Settings, AlertTriangle, Server } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils.js';
 import { getToken } from '@/lib/api.ts';
@@ -54,15 +54,15 @@ export default function Sidebar({ open, onClose }) {
             <span className="md:hidden lg:inline">Dashboard</span>
           </NavLink>
           <NavLink
-            to="/mods"
+            to="/instances"
             end
             className={linkClass}
             onClick={onClose}
-            aria-label="Mods"
-            title="Mods"
+            aria-label="Instances"
+            title="Instances"
           >
-            <Package className="h-4 w-4" aria-hidden="true" />
-            <span className="md:hidden lg:inline">Mods</span>
+            <Server className="h-4 w-4" aria-hidden="true" />
+            <span className="md:hidden lg:inline">Instances</span>
           </NavLink>
           <NavLink
             to="/settings"

--- a/frontend/src/components/dashboard/QuickActionsCard.jsx
+++ b/frontend/src/components/dashboard/QuickActionsCard.jsx
@@ -2,12 +2,10 @@ import { Button } from '@/components/ui/Button.jsx';
 import { useNavigate } from 'react-router-dom';
 import { useDashboardStore } from '@/stores/dashboardStore.js';
 import { emitDashboardRefresh } from '@/lib/refresh.js';
-import { useOpenAddMod } from '@/hooks/useOpenAddMod.js';
 
 export default function QuickActionsCard() {
   const navigate = useNavigate();
   const { loading, refreshing } = useDashboardStore();
-  const openAddMod = useOpenAddMod();
   const checking = loading || refreshing;
 
   const handleCheck = () => {
@@ -16,7 +14,7 @@ export default function QuickActionsCard() {
 
   return (
     <div className='flex flex-col gap-md'>
-      <Button onClick={openAddMod}>Add mod</Button>
+      <Button onClick={() => navigate('/instances')}>Add mod</Button>
       <Button onClick={handleCheck} disabled={checking} aria-busy={checking}>
         {checking ? 'Checking...' : 'Check updates'}
       </Button>

--- a/frontend/src/components/dashboard/SummaryCard.jsx
+++ b/frontend/src/components/dashboard/SummaryCard.jsx
@@ -25,9 +25,9 @@ function SummaryCard({ data, loading, error }) {
   }
 
   const items = [
-    { label: 'Total', value: data.tracked, to: '/mods' },
-    { label: 'Up to date', value: data.up_to_date, to: '/mods?status=up_to_date' },
-    { label: 'Outdated', value: data.outdated, to: '/mods?status=outdated' },
+    { label: 'Total', value: data.tracked, to: '/instances' },
+    { label: 'Up to date', value: data.up_to_date, to: '/instances' },
+    { label: 'Outdated', value: data.outdated, to: '/instances' },
   ];
 
   return (

--- a/frontend/src/hooks/useOpenAddMod.js
+++ b/frontend/src/hooks/useOpenAddMod.js
@@ -1,13 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import { useAddModStore } from '@/stores/addModStore.js';
 
-export function useOpenAddMod() {
+export function useOpenAddMod(instanceId) {
   const navigate = useNavigate();
   const resetWizard = useAddModStore((s) => s.resetWizard);
 
   return () => {
     resetWizard();
-    navigate('/mods/add');
+    navigate(`/instances/${instanceId}/add`);
   };
 }
 

--- a/frontend/src/pages/Instances.jsx
+++ b/frontend/src/pages/Instances.jsx
@@ -1,0 +1,335 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Server, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button.jsx';
+import { Modal } from '@/components/ui/Modal.jsx';
+import { Input } from '@/components/ui/Input.jsx';
+import { Select } from '@/components/ui/Select.jsx';
+import { Checkbox } from '@/components/ui/Checkbox.jsx';
+import { Skeleton } from '@/components/ui/Skeleton.jsx';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/Table.jsx';
+import { EmptyState } from '@/components/ui/EmptyState.jsx';
+import { getInstances, addInstance, updateInstance, deleteInstance } from '@/lib/api.ts';
+import { toast } from 'sonner';
+
+const loaders = [
+  { id: 'fabric', label: 'Fabric' },
+  { id: 'forge', label: 'Forge' },
+  { id: 'quilt', label: 'Quilt' },
+];
+
+export default function Instances() {
+  const [instances, setInstances] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [name, setName] = useState('');
+  const [loader, setLoader] = useState(loaders[0].id);
+  const [enforce, setEnforce] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchInstances();
+  }, []);
+
+  async function fetchInstances() {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await getInstances();
+      setInstances(data);
+      if (data.length === 1) {
+        navigate(`/instances/${data[0].id}`, { replace: true });
+        return;
+      }
+    } catch {
+      setError('Failed to load instances');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function openAdd() {
+    setEditing(null);
+    setName('');
+    setLoader(loaders[0].id);
+    setEnforce(true);
+    setOpen(true);
+  }
+
+  function openEdit(inst) {
+    setEditing(inst);
+    setName(inst.name);
+    setLoader(inst.loader);
+    setEnforce(inst.enforce_same_loader);
+    setOpen(true);
+  }
+
+  async function handleSave(e) {
+    e.preventDefault();
+    if (!name.trim()) {
+      toast.error('Name required');
+      return;
+    }
+    if (editing) {
+      try {
+        const updated = await updateInstance(editing.id, {
+          name,
+          loader,
+          enforce_same_loader: enforce,
+        });
+        setInstances((prev) =>
+          prev.map((i) => (i.id === updated.id ? { ...i, ...updated } : i))
+        );
+        toast.success('Instance updated');
+        setOpen(false);
+      } catch {
+        toast.error('Failed to save instance');
+      }
+      return;
+    }
+
+    const tempId = Date.now();
+    const optimistic = {
+      id: tempId,
+      name,
+      loader,
+      enforce_same_loader: enforce,
+      mod_count: 0,
+    };
+    setInstances((prev) => [...prev, optimistic]);
+    setOpen(false);
+    try {
+      const created = await addInstance({
+        name,
+        loader,
+        enforce_same_loader: enforce,
+      });
+      setInstances((prev) =>
+        prev.map((i) => (i.id === tempId ? { ...created, mod_count: 0 } : i))
+      );
+      toast.success('Instance added');
+      navigate(`/instances/${created.id}`);
+    } catch {
+      setInstances((prev) => prev.filter((i) => i.id !== tempId));
+      toast.error('Failed to save instance');
+    }
+  }
+
+  const [delState, setDelState] = useState({
+    open: false,
+    inst: null,
+    deleteMods: false,
+    targetId: null,
+  });
+
+  function openDelete(inst) {
+    const others = instances.filter((i) => i.id !== inst.id);
+    setDelState({
+      open: true,
+      inst,
+      deleteMods: others.length === 0,
+      targetId: others[0]?.id ?? null,
+    });
+  }
+
+  async function handleDelete(e) {
+    e.preventDefault();
+    const { inst, deleteMods, targetId } = delState;
+    if (!inst) return;
+    try {
+      await deleteInstance(inst.id, deleteMods ? undefined : targetId || undefined);
+      toast.success('Instance deleted');
+      setDelState({ open: false, inst: null, deleteMods: false, targetId: null });
+      fetchInstances();
+    } catch {
+      toast.error('Failed to delete instance');
+    }
+  }
+
+  return (
+    <div className="space-y-md">
+      <div className="flex justify-end">
+        <Button onClick={openAdd}>New instance</Button>
+      </div>
+      {loading && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Loader</TableHead>
+              <TableHead>Mods</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <TableRow key={i}>
+                <TableCell><Skeleton className="h-4 w-32" /></TableCell>
+                <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                <TableCell><Skeleton className="h-4 w-8" /></TableCell>
+                <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+      {!loading && error && (
+        <div className="flex flex-col items-center gap-sm">
+          <p className="text-sm text-muted-foreground">{error}</p>
+          <Button onClick={fetchInstances}>Retry</Button>
+        </div>
+      )}
+      {!loading && !error && instances.length === 0 && (
+        <EmptyState
+          icon={Server}
+          title="No instances"
+          message="You haven't added any instances yet."
+        />
+      )}
+      {!loading && !error && instances.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Loader</TableHead>
+              <TableHead>Mods</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {instances.map((inst) => (
+              <TableRow key={inst.id}>
+                <TableCell>
+                  <Link
+                    to={`/instances/${inst.id}`}
+                    className="underline hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                  >
+                    {inst.name}
+                  </Link>
+                </TableCell>
+                <TableCell>{inst.loader}</TableCell>
+                <TableCell>{inst.mod_count}</TableCell>
+                <TableCell className="flex gap-xs">
+                  <Button size="sm" onClick={() => openEdit(inst)}>
+                    Edit
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => openDelete(inst)} aria-label="Delete instance">
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <form className="space-y-md" onSubmit={handleSave}>
+          <div className="space-y-xs">
+            <label htmlFor="name" className="text-sm font-medium">
+              Name
+            </label>
+            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          {!editing ? (
+            <div className="space-y-xs">
+              <label htmlFor="loader" className="text-sm font-medium">
+                Loader
+              </label>
+              <Select id="loader" value={loader} onChange={(e) => setLoader(e.target.value)}>
+                {loaders.map((l) => (
+                  <option key={l.id} value={l.id}>
+                    {l.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : (
+            <div className="space-y-xs">
+              <span className="text-sm font-medium">Loader</span>
+              <p className="text-sm">{loader}</p>
+            </div>
+          )}
+          <div className="flex items-center gap-sm">
+            <Checkbox
+              id="enforce"
+              checked={enforce}
+              onChange={(e) => setEnforce(e.target.checked)}
+            />
+            <label htmlFor="enforce" className="text-sm">
+              Enforce same loader for mods
+            </label>
+          </div>
+          <div className="flex justify-end gap-sm">
+            <Button type="button" variant="secondary" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">{editing ? 'Save' : 'Add'}</Button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal open={delState.open} onClose={() => setDelState({ open: false, inst: null, deleteMods: false, targetId: null })}>
+        <form className="space-y-md" onSubmit={handleDelete}>
+          <h2 className="text-lg font-medium">Delete instance</h2>
+          {delState.inst && delState.inst.mod_count > 0 && (
+            <p className="text-sm">
+              This instance has {delState.inst.mod_count} mods. Choose what to do with them.
+            </p>
+          )}
+          {instances.filter((i) => delState.inst && i.id !== delState.inst.id).length > 0 && (
+            <div className="flex items-center gap-sm">
+              <Checkbox
+                id="deleteMods"
+                checked={delState.deleteMods}
+                onChange={(e) => setDelState((s) => ({ ...s, deleteMods: e.target.checked }))}
+              />
+              <label htmlFor="deleteMods" className="text-sm">
+                Delete contained mods
+              </label>
+            </div>
+          )}
+          {!delState.deleteMods &&
+            instances.filter((i) => delState.inst && i.id !== delState.inst.id).length > 0 && (
+              <div className="space-y-xs">
+                <label htmlFor="target" className="text-sm font-medium">
+                  Move mods to
+                </label>
+                <Select
+                  id="target"
+                  value={delState.targetId ?? ''}
+                  onChange={(e) =>
+                    setDelState((s) => ({ ...s, targetId: Number(e.target.value) }))
+                  }
+                >
+                  {instances
+                    .filter((i) => delState.inst && i.id !== delState.inst.id)
+                    .map((i) => (
+                      <option key={i.id} value={i.id}>
+                        {i.name}
+                      </option>
+                    ))}
+                </Select>
+              </div>
+            )}
+          <div className="flex justify-end gap-sm">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() =>
+                setDelState({ open: false, inst: null, deleteMods: false, targetId: null })
+              }
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!delState.deleteMods && !delState.targetId}>
+              Delete
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/pages/Instances.test.jsx
+++ b/frontend/src/pages/Instances.test.jsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock("@/lib/api.ts", () => ({
+  getInstances: vi.fn(),
+  addInstance: vi.fn(),
+  updateInstance: vi.fn(),
+  deleteInstance: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("focus-trap-react", () => ({
+  default: ({ children }) => children,
+}));
+
+import { MemoryRouter } from "react-router-dom";
+import Instances from "./Instances.jsx";
+import {
+  getInstances,
+  addInstance,
+  updateInstance,
+  deleteInstance,
+} from "@/lib/api.ts";
+import { toast } from "sonner";
+
+describe("Instances page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows empty state when no instances", async () => {
+    getInstances.mockResolvedValueOnce([]);
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("No instances")).toBeInTheDocument();
+  });
+
+  it("shows error state on failure", async () => {
+    getInstances.mockRejectedValueOnce(new Error("oops"));
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+    expect(
+      await screen.findByText("Failed to load instances"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("redirects to single instance", async () => {
+    getInstances.mockResolvedValueOnce([
+      { id: 1, name: "Default", loader: "fabric", enforce_same_loader: true },
+    ]);
+    render(
+      <MemoryRouter initialEntries={["/instances"]}>
+        <Instances />
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("/instances/1", { replace: true }),
+    );
+  });
+
+  it("creates instance and navigates", async () => {
+    getInstances.mockResolvedValueOnce([]);
+    const promise = Promise.resolve({
+      id: 1,
+      name: "Test",
+      loader: "fabric",
+      enforce_same_loader: true,
+    });
+    addInstance.mockReturnValue(promise);
+
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+
+    const [newBtn] = await screen.findAllByRole("button", {
+      name: /new instance/i,
+    });
+    fireEvent.click(newBtn);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(screen.getByText("Test")).toBeInTheDocument();
+
+    await promise;
+    await waitFor(() =>
+      expect(addInstance).toHaveBeenCalledWith({
+        name: "Test",
+        loader: "fabric",
+        enforce_same_loader: true,
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Instance added");
+    expect(navigate).toHaveBeenCalledWith("/instances/1");
+  });
+
+  it("validates name is required", async () => {
+    getInstances.mockResolvedValueOnce([]);
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+
+    const [newBtn] = await screen.findAllByRole("button", {
+      name: /new instance/i,
+    });
+    fireEvent.click(newBtn);
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(addInstance).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Name required");
+  });
+
+  it("creates instance with enforcement disabled", async () => {
+    getInstances.mockResolvedValueOnce([]);
+    const promise = Promise.resolve({
+      id: 1,
+      name: "Test",
+      loader: "fabric",
+      enforce_same_loader: false,
+    });
+    addInstance.mockReturnValue(promise);
+
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+
+    const [newBtn] = await screen.findAllByRole("button", {
+      name: /new instance/i,
+    });
+    fireEvent.click(newBtn);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Test" },
+    });
+    fireEvent.click(screen.getByLabelText("Enforce same loader for mods"));
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await promise;
+    await waitFor(() =>
+      expect(addInstance).toHaveBeenCalledWith({
+        name: "Test",
+        loader: "fabric",
+        enforce_same_loader: false,
+      }),
+    );
+  });
+
+  it("updates instance and toggles enforcement", async () => {
+    getInstances.mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "One",
+        loader: "fabric",
+        enforce_same_loader: true,
+        mod_count: 0,
+      },
+      {
+        id: 2,
+        name: "Two",
+        loader: "forge",
+        enforce_same_loader: true,
+        mod_count: 0,
+      },
+    ]);
+    updateInstance.mockResolvedValue({
+      id: 1,
+      name: "One!",
+      loader: "fabric",
+      enforce_same_loader: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+
+    const [editBtn] = await screen.findAllByRole("button", { name: "Edit" });
+    fireEvent.click(editBtn);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "One!" },
+    });
+    fireEvent.click(screen.getByLabelText("Enforce same loader for mods"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateInstance).toHaveBeenCalledWith(1, {
+        name: "One!",
+        loader: "fabric",
+        enforce_same_loader: false,
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Instance updated");
+  });
+});

--- a/frontend/src/pages/InstancesSkeleton.jsx
+++ b/frontend/src/pages/InstancesSkeleton.jsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/ui/Skeleton.jsx';
+
+export default function InstancesSkeleton() {
+  return (
+    <div className="space-y-md">
+      <div className="flex justify-end">
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="space-y-sm">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-6 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Mods.test.jsx
+++ b/frontend/src/pages/Mods.test.jsx
@@ -1,0 +1,170 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("focus-trap-react", () => ({
+  default: ({ children }) => children,
+}));
+
+vi.mock("@/lib/api.ts", () => ({
+  getMods: vi.fn(),
+  refreshMod: vi.fn(),
+  deleteMod: vi.fn(),
+  getToken: vi.fn(),
+  getInstance: vi.fn(),
+  updateInstance: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const confirmMock = vi.fn();
+vi.mock("@/hooks/useConfirm.jsx", () => ({
+  useConfirm: () => ({ confirm: confirmMock, ConfirmModal: null }),
+}));
+
+import Mods from "./Mods.jsx";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import {
+  getMods,
+  getInstance,
+  updateInstance,
+  getToken,
+  refreshMod,
+  deleteMod,
+} from "@/lib/api.ts";
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/instances/1"]}>
+      <Routes>
+        <Route path="/instances/:id" element={<Mods />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Mods instance editing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getToken.mockResolvedValue("token");
+    confirmMock.mockResolvedValue(true);
+    getMods.mockResolvedValue([]);
+    getInstance.mockResolvedValue({
+      id: 1,
+      name: "Old",
+      loader: "fabric",
+      enforce_same_loader: true,
+      created_at: "",
+      mod_count: 0,
+    });
+  });
+
+  it("renames and toggles enforcement", async () => {
+    updateInstance
+      .mockResolvedValueOnce({
+        id: 1,
+        name: "New",
+        loader: "fabric",
+        enforce_same_loader: true,
+        created_at: "",
+        mod_count: 0,
+      })
+      .mockResolvedValueOnce({
+        id: 1,
+        name: "New",
+        loader: "fabric",
+        enforce_same_loader: false,
+        created_at: "",
+        mod_count: 0,
+      });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole("heading", { name: /Old/ }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Rename instance"));
+    const input = screen.getByDisplayValue("Old");
+    fireEvent.change(input, { target: { value: "New" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateInstance).toHaveBeenCalledWith(1, {
+        name: "New",
+        loader: "fabric",
+        enforce_same_loader: true,
+      }),
+    );
+    expect(screen.getByRole("heading", { name: /New/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const checkbox = screen.getByLabelText("Enforce same loader for mods");
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateInstance).toHaveBeenLastCalledWith(1, {
+        name: "New",
+        loader: "fabric",
+        enforce_same_loader: false,
+      }),
+    );
+  });
+});
+
+describe("Mods instance scoping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getToken.mockResolvedValue("token");
+    confirmMock.mockResolvedValue(true);
+    getInstance.mockResolvedValue({
+      id: 1,
+      name: "Inst",
+      loader: "fabric",
+      enforce_same_loader: true,
+      created_at: "",
+      mod_count: 0,
+    });
+    const modA = {
+      id: 1,
+      name: "Alpha",
+      url: "https://example.com/a",
+      game_version: "1.20",
+      loader: "fabric",
+      current_version: "1.0",
+      available_version: "1.0",
+      channel: "release",
+      instance_id: 1,
+    };
+    getMods.mockResolvedValue([modA]);
+    refreshMod.mockResolvedValue([modA]);
+    deleteMod.mockResolvedValue([]);
+  });
+
+  it("shows loader in header and loads mods for the instance", async () => {
+    renderPage();
+    await waitFor(() => expect(getMods).toHaveBeenCalledWith(1));
+    const heading = await screen.findByRole("heading", { name: /Inst/ });
+    expect(heading).toHaveTextContent("Inst");
+    expect(heading).toHaveTextContent("fabric");
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+  });
+
+  it("handles refresh and delete within the instance", async () => {
+    renderPage();
+    fireEvent.click(
+      await screen.findByLabelText("Check for updates"),
+    );
+    await waitFor(() =>
+      expect(refreshMod).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ instance_id: 1 }),
+      ),
+    );
+    fireEvent.click(screen.getAllByLabelText("Delete mod")[0]);
+    await waitFor(() => expect(deleteMod).toHaveBeenCalledWith(1, 1));
+  });
+});

--- a/internal/db/migration_test.go
+++ b/internal/db/migration_test.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestInitCreatesDefaultInstance(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	// Simulate pre-migration mods table without instances.
+	if _, err := db.Exec(`CREATE TABLE mods (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, url TEXT NOT NULL, loader TEXT)`); err != nil {
+		t.Fatalf("create mods table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO mods(name, url, loader) VALUES('A', 'u', 'fabric')`); err != nil {
+		t.Fatalf("insert mod: %v", err)
+	}
+
+	if err := Init(db); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	var id int
+	var loader string
+	if err := db.QueryRow(`SELECT id, loader FROM instances LIMIT 1`).Scan(&id, &loader); err != nil {
+		t.Fatalf("select instance: %v", err)
+	}
+	if loader != "fabric" {
+		t.Fatalf("expected loader fabric, got %s", loader)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM mods WHERE instance_id=?`, id).Scan(&count); err != nil {
+		t.Fatalf("count mods: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("mods not migrated: %d", count)
+	}
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,226 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	dbpkg "modsentinel/internal/db"
+	"modsentinel/internal/httpx"
+	mr "modsentinel/internal/modrinth"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	return db
+}
+
+type fakeModClient struct{}
+
+func (fakeModClient) Project(ctx context.Context, slug string) (*mr.Project, error) {
+	return &mr.Project{Title: "Fake", IconURL: ""}, nil
+}
+
+func (fakeModClient) Versions(ctx context.Context, slug, gameVersion, loader string) ([]mr.Version, error) {
+	return []mr.Version{{
+		ID:            "1",
+		VersionNumber: "1.0",
+		VersionType:   "release",
+		DatePublished: time.Now(),
+		Files:         []mr.VersionFile{{URL: "http://example.com"}},
+	}}, nil
+}
+
+func TestCreateModHandler_EnforceLoader(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	inst := &dbpkg.Instance{Name: "A", Loader: "fabric", EnforceSameLoader: true}
+	if err := dbpkg.InsertInstance(db, inst); err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
+
+	h := createModHandler(db)
+
+	payload := `{"url":"https://modrinth.com/mod/sodium","game_version":"1.20","loader":"forge","channel":"release","instance_id":` + strconv.Itoa(inst.ID) + `}`
+	req := httptest.NewRequest(http.MethodPost, "/api/mods", strings.NewReader(payload))
+	w := httptest.NewRecorder()
+
+	h(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", w.Code)
+	}
+	var errResp httpx.Error
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errResp.Message != "loader mismatch" {
+		t.Fatalf("want loader mismatch, got %q", errResp.Message)
+	}
+}
+
+func TestListModsHandler_ScopeAndCache(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	inst1 := &dbpkg.Instance{Name: "A", Loader: "fabric"}
+	if err := dbpkg.InsertInstance(db, inst1); err != nil {
+		t.Fatalf("insert inst1: %v", err)
+	}
+	inst2 := &dbpkg.Instance{Name: "B", Loader: "forge"}
+	if err := dbpkg.InsertInstance(db, inst2); err != nil {
+		t.Fatalf("insert inst2: %v", err)
+	}
+
+	if err := dbpkg.InsertMod(db, &dbpkg.Mod{Name: "M1", URL: "u1", InstanceID: inst1.ID}); err != nil {
+		t.Fatalf("insert mod1: %v", err)
+	}
+	if err := dbpkg.InsertMod(db, &dbpkg.Mod{Name: "M2", URL: "u2", InstanceID: inst2.ID}); err != nil {
+		t.Fatalf("insert mod2: %v", err)
+	}
+
+	h := listModsHandler(db)
+	req := httptest.NewRequest(http.MethodGet, "/api/mods?instance_id="+strconv.Itoa(inst1.ID), nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "max-age=60" {
+		t.Fatalf("cache-control %q", cc)
+	}
+	var mods []dbpkg.Mod
+	if err := json.NewDecoder(w.Body).Decode(&mods); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(mods) != 1 || mods[0].InstanceID != inst1.ID {
+		t.Fatalf("unexpected mods: %v", mods)
+	}
+}
+
+func TestInstanceHandlers_CRUD(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	// Create with default enforcement (true)
+	create := createInstanceHandler(db)
+	req := httptest.NewRequest(http.MethodPost, "/api/instances", strings.NewReader(`{"name":"A","loader":"fabric"}`))
+	w := httptest.NewRecorder()
+	create(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create status %d", w.Code)
+	}
+	var inst dbpkg.Instance
+	if err := json.NewDecoder(w.Body).Decode(&inst); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if !inst.EnforceSameLoader {
+		t.Fatalf("expected enforcement default true")
+	}
+
+	// Create with enforcement disabled
+	req2 := httptest.NewRequest(http.MethodPost, "/api/instances", strings.NewReader(`{"name":"B","loader":"forge","enforce_same_loader":false}`))
+	w2 := httptest.NewRecorder()
+	create(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("create2 status %d", w2.Code)
+	}
+	var inst2 dbpkg.Instance
+	if err := json.NewDecoder(w2.Body).Decode(&inst2); err != nil {
+		t.Fatalf("decode create2: %v", err)
+	}
+	if inst2.EnforceSameLoader {
+		t.Fatalf("expected enforcement false")
+	}
+
+	// Update second instance to enable enforcement
+	update := updateInstanceHandler(db)
+	payload := fmt.Sprintf(`{"name":"B2","loader":"forge","enforce_same_loader":true}`)
+	req3 := httptest.NewRequest(http.MethodPut, "/api/instances/"+strconv.Itoa(inst2.ID), strings.NewReader(payload))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.Itoa(inst2.ID))
+	req3 = req3.WithContext(context.WithValue(req3.Context(), chi.RouteCtxKey, rctx))
+	w3 := httptest.NewRecorder()
+	update(w3, req3)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("update status %d", w3.Code)
+	}
+	var instUpd dbpkg.Instance
+	if err := json.NewDecoder(w3.Body).Decode(&instUpd); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if !instUpd.EnforceSameLoader {
+		t.Fatalf("expected enforcement true after update")
+	}
+
+	// Delete first instance
+	deleteH := deleteInstanceHandler(db)
+	req4 := httptest.NewRequest(http.MethodDelete, "/api/instances/"+strconv.Itoa(inst.ID), nil)
+	rctx4 := chi.NewRouteContext()
+	rctx4.URLParams.Add("id", strconv.Itoa(inst.ID))
+	req4 = req4.WithContext(context.WithValue(req4.Context(), chi.RouteCtxKey, rctx4))
+	w4 := httptest.NewRecorder()
+	deleteH(w4, req4)
+	if w4.Code != http.StatusNoContent {
+		t.Fatalf("delete status %d", w4.Code)
+	}
+	if _, err := dbpkg.GetInstance(db, inst.ID); err == nil {
+		t.Fatalf("instance not deleted")
+	}
+}
+
+func TestCreateModHandler_WarningWithoutEnforcement(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	inst := &dbpkg.Instance{Name: "A", Loader: "fabric", EnforceSameLoader: false}
+	if err := dbpkg.InsertInstance(db, inst); err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
+
+	oldClient := modClient
+	modClient = fakeModClient{}
+	defer func() { modClient = oldClient }()
+
+	h := createModHandler(db)
+	payload := `{"url":"https://modrinth.com/mod/sodium","game_version":"1.20","loader":"forge","channel":"release","instance_id":` + strconv.Itoa(inst.ID) + `}`
+	req := httptest.NewRequest(http.MethodPost, "/api/mods", strings.NewReader(payload))
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	var resp struct {
+		Mods    []dbpkg.Mod `json:"mods"`
+		Warning string      `json:"warning"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Warning != "loader mismatch" {
+		t.Fatalf("expected warning, got %q", resp.Warning)
+	}
+	if len(resp.Mods) != 1 || resp.Mods[0].InstanceID != inst.ID {
+		t.Fatalf("unexpected mods: %v", resp.Mods)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,10 @@ func openTestDB(t *testing.T) *sql.DB {
 	if err := initDB(db); err != nil {
 		t.Fatalf("init db: %v", err)
 	}
+	inst := &Instance{Name: "Test", Loader: "fabric", EnforceSameLoader: true}
+	if err := insertInstance(db, inst); err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
 	return db
 }
 
@@ -88,11 +92,11 @@ func TestDatabaseOperations(t *testing.T) {
 		{
 			name: "insert",
 			run: func(db *sql.DB) error {
-				m := &Mod{Name: "A", URL: "u"}
+				m := &Mod{Name: "A", URL: "u", InstanceID: 1}
 				if err := insertMod(db, m); err != nil {
 					return err
 				}
-				mods, err := listMods(db)
+				mods, err := listMods(db, 1)
 				if err != nil {
 					return err
 				}
@@ -113,7 +117,7 @@ func TestDatabaseOperations(t *testing.T) {
 		{
 			name: "update",
 			run: func(db *sql.DB) error {
-				m := &Mod{Name: "Old", URL: "u"}
+				m := &Mod{Name: "Old", URL: "u", InstanceID: 1}
 				if err := insertMod(db, m); err != nil {
 					return err
 				}
@@ -121,7 +125,7 @@ func TestDatabaseOperations(t *testing.T) {
 				if err := updateMod(db, m); err != nil {
 					return err
 				}
-				mods, err := listMods(db)
+				mods, err := listMods(db, 1)
 				if err != nil {
 					return err
 				}
@@ -143,14 +147,14 @@ func TestDatabaseOperations(t *testing.T) {
 		{
 			name: "delete",
 			run: func(db *sql.DB) error {
-				m := &Mod{Name: "Del", URL: "u"}
+				m := &Mod{Name: "Del", URL: "u", InstanceID: 1}
 				if err := insertMod(db, m); err != nil {
 					return err
 				}
 				if err := deleteMod(db, m.ID); err != nil {
 					return err
 				}
-				mods, err := listMods(db)
+				mods, err := listMods(db, 1)
 				if err != nil {
 					return err
 				}
@@ -171,7 +175,7 @@ func TestDatabaseOperations(t *testing.T) {
 		{
 			name: "list empty",
 			run: func(db *sql.DB) error {
-				mods, err := listMods(db)
+				mods, err := listMods(db, 1)
 				if err != nil {
 					return err
 				}
@@ -185,7 +189,7 @@ func TestDatabaseOperations(t *testing.T) {
 			name: "list error",
 			run: func(db *sql.DB) error {
 				db.Close()
-				_, err := listMods(db)
+				_, err := listMods(db, 1)
 				return err
 			},
 			wantErr: true,


### PR DESCRIPTION
## Summary
- mock Modrinth client for tests via a small interface
- cover instance CRUD and loader-mismatch warning paths in backend tests
- exercise instance creation and update flows, including enforcement toggling, in frontend tests
- wrap header layout and instance switcher for mobile and let the Mods header flex-wrap

## Testing
- `npx tsc --noEmit`
- `npx eslint src/components/Header.jsx src/components/InstanceSwitcher.jsx src/pages/Mods.jsx` *(fails: ESLint couldn't find config)*
- `npx axe index.html` *(fails: could not determine executable)*
- `npx lighthouse index.html --output=json --quiet` *(canceled: dependency not installed)*
- `go test ./...`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a580312c088321b400c5afcc026978