### PR TITLE
pufferpanel: singleflight server listing by base URL

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -92,11 +92,11 @@ func writePPError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.As(err, &pe) {
 		switch {
 		case pe.Status == http.StatusBadRequest:
-			httpx.Write(w, r, httpx.BadRequest(pe.Error()))
+			httpx.Write(w, r, httpx.BadRequest("bad request to PufferPanel; check base URL"))
 		case pe.Status == http.StatusUnauthorized:
-			httpx.Write(w, r, httpx.Unauthorized(pe.Error()))
+			httpx.Write(w, r, httpx.Unauthorized("invalid PufferPanel credentials"))
 		case pe.Status == http.StatusForbidden:
-			httpx.Write(w, r, httpx.Forbidden(pe.Error()))
+			httpx.Write(w, r, httpx.Forbidden("insufficient PufferPanel permissions"))
 		case pe.Status >= 500:
 			httpx.Write(w, r, httpx.BadGateway(pe.Error()))
 		default:

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1036,7 +1036,7 @@ func TestListServersHandler_OK(t *testing.T) {
 	}
 }
 
-func TestListServersHandler_PropagatesError(t *testing.T) {
+func TestListServersHandler_Upstream403(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 	initSecrets(t, db)
@@ -1068,7 +1068,7 @@ func TestListServersHandler_PropagatesError(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&e); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if e.Code != "forbidden" || e.Message != "nope" {
+	if e.Code != "forbidden" || e.Message != "insufficient PufferPanel permissions" {
 		t.Fatalf("unexpected error %+v", e)
 	}
 	if e.RequestID == "" {
@@ -1108,7 +1108,7 @@ func TestListServersHandler_Upstream400(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&e); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if e.Code != "bad_request" || e.Message != "bad" {
+	if e.Code != "bad_request" || e.Message != "bad request to PufferPanel; check base URL" {
 		t.Fatalf("unexpected error %+v", e)
 	}
 	if e.RequestID == "" {
@@ -1148,7 +1148,7 @@ func TestListServersHandler_Upstream401(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&e); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if e.Code != "token_required" || e.Message != "unauth" {
+	if e.Code != "unauthorized" || e.Message != "invalid PufferPanel credentials" {
 		t.Fatalf("unexpected error %+v", e)
 	}
 	if e.RequestID == "" {

--- a/internal/httpx/errors.go
+++ b/internal/httpx/errors.go
@@ -43,7 +43,7 @@ func BadRequest(msg string) *HTTPError {
 
 // Unauthorized returns a 401 HTTPError.
 func Unauthorized(msg string) *HTTPError {
-	return &HTTPError{status: http.StatusUnauthorized, code: "token_required", message: msg}
+	return &HTTPError{status: http.StatusUnauthorized, code: "unauthorized", message: msg}
 }
 
 // Forbidden returns a 403 HTTPError.

--- a/internal/pufferpanel/credentials.go
+++ b/internal/pufferpanel/credentials.go
@@ -56,6 +56,20 @@ func Get() (Credentials, error) {
 	if err := json.Unmarshal(b, &c); err != nil {
 		return Credentials{}, err
 	}
+	orig := c.BaseURL
+	if err := validateCreds(&c); err != nil {
+		return Credentials{}, err
+	}
+	if c.BaseURL != orig {
+		nb, err := json.Marshal(c)
+		if err != nil {
+			return Credentials{}, err
+		}
+		if err := svc.Set(context.Background(), "pufferpanel", nb); err != nil {
+			return Credentials{}, err
+		}
+	}
+	baseURL.Store(parseHost(c.BaseURL))
 	return c, nil
 }
 

--- a/internal/pufferpanel/credentials_test.go
+++ b/internal/pufferpanel/credentials_test.go
@@ -1,0 +1,57 @@
+package pufferpanel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSetValidatesAndNormalizesBaseURL(t *testing.T) {
+	setup(t)
+	if err := Set(Credentials{BaseURL: "ftp://foo", ClientID: "id", ClientSecret: "secret"}); err == nil {
+		t.Fatalf("expected error for invalid scheme")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	if err := Set(Credentials{BaseURL: srv.URL + "/", ClientID: "id", ClientSecret: "secret"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	c, err := Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if c.BaseURL != srv.URL {
+		t.Fatalf("base URL = %s, want %s", c.BaseURL, srv.URL)
+	}
+}
+
+func TestGetNormalizesExistingBaseURL(t *testing.T) {
+	setup(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	raw := fmt.Sprintf(`{"base_url":"%s/","client_id":"id","client_secret":"secret"}`, srv.URL)
+	if err := svc.Set(context.Background(), "pufferpanel", []byte(raw)); err != nil {
+		t.Fatalf("seed creds: %v", err)
+	}
+	c, err := Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if c.BaseURL != srv.URL {
+		t.Fatalf("BaseURL = %s, want %s", c.BaseURL, srv.URL)
+	}
+	b, err := svc.DecryptForUse(context.Background(), "pufferpanel")
+	if err != nil {
+		t.Fatalf("DecryptForUse: %v", err)
+	}
+	var stored Credentials
+	if err := json.Unmarshal(b, &stored); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if stored.BaseURL != srv.URL {
+		t.Fatalf("stored BaseURL = %s, want %s", stored.BaseURL, srv.URL)
+	}
+}

--- a/internal/pufferpanel/files.go
+++ b/internal/pufferpanel/files.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 )
 
 // FileEntry represents a file or directory returned by PufferPanel's file listing API.
@@ -36,7 +35,7 @@ func listFiles(ctx context.Context, serverID, path string) ([]FileEntry, error) 
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := newClient(u)
 	status, body, err := doAuthRequest(ctx, client, req)
 	if err != nil {
 		return nil, err
@@ -72,7 +71,7 @@ func FetchFile(ctx context.Context, serverID, path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := newClient(u)
 	status, body, err := doAuthRequest(ctx, client, req)
 	if err != nil {
 		return nil, err

--- a/internal/pufferpanel/http_test.go
+++ b/internal/pufferpanel/http_test.go
@@ -1,0 +1,32 @@
+package pufferpanel
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestNewClientTimeouts(t *testing.T) {
+	base, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	c := newClient(base)
+	if c.Timeout != 30*time.Second {
+		t.Fatalf("Timeout = %v, want 30s", c.Timeout)
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *http.Transport", c.Transport)
+	}
+	if tr.TLSHandshakeTimeout != 5*time.Second {
+		t.Fatalf("TLSHandshakeTimeout = %v, want 5s", tr.TLSHandshakeTimeout)
+	}
+	if tr.ResponseHeaderTimeout != 10*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %v, want 10s", tr.ResponseHeaderTimeout)
+	}
+	if tr.ExpectContinueTimeout != 1*time.Second {
+		t.Fatalf("ExpectContinueTimeout = %v, want 1s", tr.ExpectContinueTimeout)
+	}
+}

--- a/internal/pufferpanel/servers.go
+++ b/internal/pufferpanel/servers.go
@@ -7,9 +7,12 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/singleflight"
+
+	"modsentinel/internal/telemetry"
 )
 
 // Server represents a PufferPanel server.
@@ -19,9 +22,10 @@ type Server struct {
 }
 
 type paging struct {
-	Page  int `json:"page"`
-	Size  int `json:"size"`
-	Total int `json:"total"`
+	Page  int    `json:"page"`
+	Size  int    `json:"size"`
+	Total int    `json:"total"`
+	Next  string `json:"next"`
 }
 
 type serverList struct {
@@ -32,38 +36,74 @@ type serverList struct {
 var (
 	serverGroup singleflight.Group
 	maxServers  = 1000
+	serverTTL   = 2 * time.Second
+	serverCache sync.Map // map[baseURL]cacheEntry
 )
 
-// ListServers fetches available servers from PufferPanel.
-func ListServers(ctx context.Context) ([]Server, error) {
-	v, err, _ := serverGroup.Do("servers", func() (any, error) {
-		return fetchServers(ctx)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return v.([]Server), nil
+type cacheEntry struct {
+	servers []Server
+	exp     time.Time
 }
 
-func fetchServers(ctx context.Context) ([]Server, error) {
+// ListServers fetches available servers from PufferPanel.
+func ListServers(ctx context.Context) (servers []Server, err error) {
+	start := time.Now()
+	cacheHit := false
+	deduped := false
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "error"
+		}
+		telemetry.Event("pufferpanel_request", map[string]string{
+			"resource":    "pufferpanel.servers",
+			"status":      status,
+			"duration_ms": strconv.FormatInt(time.Since(start).Milliseconds(), 10),
+			"deduped":     strconv.FormatBool(deduped),
+			"cache_hit":   strconv.FormatBool(cacheHit),
+		})
+	}()
+
 	creds, err := getCreds()
 	if err != nil {
 		return nil, err
 	}
-	u, err := url.Parse(creds.BaseURL)
+	if v, ok := serverCache.Load(creds.BaseURL); ok {
+		ent := v.(cacheEntry)
+		if time.Now().Before(ent.exp) {
+			cacheHit = true
+			return ent.servers, nil
+		}
+	}
+	var shared bool
+	var v any
+	v, err, shared = serverGroup.Do(creds.BaseURL, func() (any, error) {
+		svs, err := fetchServers(ctx, creds)
+		if err != nil {
+			return nil, err
+		}
+		serverCache.Store(creds.BaseURL, cacheEntry{servers: svs, exp: time.Now().Add(serverTTL)})
+		return svs, nil
+	})
+	deduped = shared
 	if err != nil {
 		return nil, err
 	}
-	u.Path = strings.TrimSuffix(u.Path, "/") + "/api/servers"
-	client := &http.Client{Timeout: 10 * time.Second}
+	servers = v.([]Server)
+	return servers, nil
+}
+
+func fetchServers(ctx context.Context, creds Credentials) ([]Server, error) {
+	base, err := url.Parse(creds.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	nextURL := *base
+	nextURL.Path = strings.TrimSuffix(nextURL.Path, "/") + "/api/servers"
+	client := newClient(base)
 	var all []Server
-	// PufferPanel pagination starts at 1, so begin with page 1.
-	for page := 1; ; page++ {
-		reqURL := *u
-		q := reqURL.Query()
-		q.Set("page", strconv.Itoa(page))
-		reqURL.RawQuery = q.Encode()
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL.String(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -79,12 +119,23 @@ func fetchServers(ctx context.Context) ([]Server, error) {
 			return nil, err
 		}
 		all = append(all, res.Servers...)
-		if len(all) >= res.Paging.Total || len(res.Servers) == 0 || len(all) >= maxServers {
+		if len(all) >= res.Paging.Total || len(res.Servers) == 0 || len(all) >= maxServers || res.Paging.Next == "" {
 			if len(all) > maxServers {
 				all = all[:maxServers]
 			}
 			break
 		}
+		u, err := url.Parse(res.Paging.Next)
+		if err != nil {
+			return nil, err
+		}
+		if u.IsAbs() {
+			u.Scheme = base.Scheme
+			u.Host = base.Host
+		} else {
+			u = base.ResolveReference(u)
+		}
+		nextURL = *u
 	}
 	return all, nil
 }
@@ -113,7 +164,7 @@ func GetServer(ctx context.Context, id string) (*ServerDetail, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := newClient(u)
 	status, body, err := doAuthRequest(ctx, client, req)
 	if err != nil {
 		return nil, err

--- a/internal/pufferpanel/servers_test.go
+++ b/internal/pufferpanel/servers_test.go
@@ -1,15 +1,22 @@
 package pufferpanel
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	dbpkg "modsentinel/internal/db"
 	"modsentinel/internal/secrets"
@@ -32,6 +39,8 @@ func setupCreds(t *testing.T, base string) {
 		t.Fatalf("load keys: %v", err)
 	}
 	Init(secrets.NewService(db, km))
+	resetToken()
+	serverCache = sync.Map{}
 	if err := Set(Credentials{BaseURL: base, ClientID: "id", ClientSecret: "secret"}); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
@@ -45,11 +54,11 @@ func TestListServers(t *testing.T) {
 		case "/api/servers":
 			switch r.URL.Query().Get("page") {
 			case "", "1":
-				fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":2},"servers":[{"id":"1","name":"One"}]}`)
+				fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":2,"next":"/api/servers?page=2"},"servers":[{"id":"1","name":"One"}]}`)
 			case "2":
-				fmt.Fprint(w, `{"paging":{"page":2,"size":1,"total":2},"servers":[{"id":"2","name":"Two"}]}`)
+				fmt.Fprint(w, `{"paging":{"page":2,"size":1,"total":2,"next":""},"servers":[{"id":"2","name":"Two"}]}`)
 			default:
-				fmt.Fprint(w, `{"paging":{"page":3,"size":1,"total":2},"servers":[]}`)
+				http.NotFound(w, r)
 			}
 		default:
 			http.NotFound(w, r)
@@ -106,9 +115,16 @@ func TestListServersLimit(t *testing.T) {
 		case "/oauth2/token":
 			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
 		case "/api/servers":
-			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-			fmt.Fprintf(w, `{"paging":{"page":%d,"size":1,"total":5},"servers":[{"id":"%d","name":"S%d"}]}`,
-				page, page+1, page+1)
+			page := 1
+			if p := r.URL.Query().Get("page"); p != "" {
+				page, _ = strconv.Atoi(p)
+			}
+			next := ""
+			if page < 5 {
+				next = fmt.Sprintf("/api/servers?page=%d", page+1)
+			}
+			fmt.Fprintf(w, `{"paging":{"page":%d,"size":1,"total":5,"next":"%s"},"servers":[{"id":"%d","name":"S%d"}]}`,
+				page, next, page+1, page+1)
 		default:
 			http.NotFound(w, r)
 		}
@@ -136,9 +152,9 @@ func TestListServersDebounce(t *testing.T) {
 		case "/api/servers":
 			if p := r.URL.Query().Get("page"); p == "" || p == "1" {
 				calls.Add(1)
-				fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1},"servers":[{"id":"1","name":"One"}]}`)
+				fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
 			} else {
-				fmt.Fprint(w, `{"paging":{"page":2,"size":1,"total":1},"servers":[]}`)
+				fmt.Fprint(w, `{"paging":{"page":2,"size":1,"total":1,"next":""},"servers":[]}`)
 			}
 		default:
 			http.NotFound(w, r)
@@ -147,18 +163,120 @@ func TestListServersDebounce(t *testing.T) {
 	defer srv.Close()
 	setupCreds(t, srv.URL)
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	start := make(chan struct{})
+	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
 			if _, err := ListServers(context.Background()); err != nil {
 				t.Errorf("ListServers: %v", err)
 			}
 		}()
 	}
+	close(start)
 	wg.Wait()
 	if calls.Load() != 1 {
 		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestListServersCache(t *testing.T) {
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+		case "/api/servers":
+			calls.Add(1)
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	setupCreds(t, srv.URL)
+	old := serverTTL
+	serverTTL = 50 * time.Millisecond
+	t.Cleanup(func() { serverTTL = old })
+	ctx := context.Background()
+	if _, err := ListServers(ctx); err != nil {
+		t.Fatalf("ListServers 1: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls after first = %d, want 1", calls.Load())
+	}
+	if _, err := ListServers(ctx); err != nil {
+		t.Fatalf("ListServers 2: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls after cache = %d, want 1", calls.Load())
+	}
+	time.Sleep(serverTTL + 20*time.Millisecond)
+	if _, err := ListServers(ctx); err != nil {
+		t.Fatalf("ListServers 3: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("calls after ttl = %d, want 2", calls.Load())
+	}
+}
+
+func TestListServersConcurrentCache(t *testing.T) {
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+		case "/api/servers":
+			calls.Add(1)
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	setupCreds(t, srv.URL)
+	old := serverTTL
+	serverTTL = 50 * time.Millisecond
+	t.Cleanup(func() { serverTTL = old })
+
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := ListServers(ctx); err != nil {
+				t.Errorf("ListServers: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if calls.Load() != 1 {
+		t.Fatalf("calls after first = %d, want 1", calls.Load())
+	}
+
+	time.Sleep(serverTTL + 20*time.Millisecond)
+
+	start = make(chan struct{})
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := ListServers(ctx); err != nil {
+				t.Errorf("ListServers 2: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if calls.Load() != 2 {
+		t.Fatalf("calls after second = %d, want 2", calls.Load())
 	}
 }
 
@@ -174,7 +292,7 @@ func TestListServersRefreshesTokenOnUnauthorized(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
-			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1},"servers":[{"id":"1","name":"One"}]}`)
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
 		default:
 			http.NotFound(w, r)
 		}
@@ -193,5 +311,167 @@ func TestListServersRefreshesTokenOnUnauthorized(t *testing.T) {
 	}
 	if tokenCalls.Load() != 2 {
 		t.Fatalf("token calls after second list = %d, want 2", tokenCalls.Load())
+	}
+}
+
+func TestListServersNextAbsolute(t *testing.T) {
+	var calls atomic.Int64
+	var page2Host string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+		case "/api/servers":
+			calls.Add(1)
+			if r.URL.Query().Get("page") == "2" {
+				page2Host = r.Host
+				fmt.Fprint(w, `{"paging":{"page":2,"size":1,"total":2,"next":""},"servers":[{"id":"2","name":"Two"}]}`)
+				return
+			}
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":2,"next":"https://evil.com/api/servers?page=2"},"servers":[{"id":"1","name":"One"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	setupCreds(t, srv.URL)
+	svs, err := ListServers(context.Background())
+	if err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+	base, _ := url.Parse(srv.URL)
+	if len(svs) != 2 || calls.Load() != 2 || page2Host != base.Host {
+		t.Fatalf("servers=%d calls=%d host=%s want host %s", len(svs), calls.Load(), page2Host, base.Host)
+	}
+}
+
+func TestListServersRedirectSameOrigin(t *testing.T) {
+	var calls atomic.Int64
+	var redirectHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+		case "/api/servers":
+			http.Redirect(w, r, "https://evil.com/api/servers2", http.StatusFound)
+		case "/api/servers2":
+			calls.Add(1)
+			redirectHost = r.Host
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	setupCreds(t, srv.URL)
+	svs, err := ListServers(context.Background())
+	if err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+	base, _ := url.Parse(srv.URL)
+	if len(svs) != 1 || calls.Load() != 1 || redirectHost != base.Host {
+		t.Fatalf("servers=%d calls=%d host=%s want host %s", len(svs), calls.Load(), redirectHost, base.Host)
+	}
+}
+
+func TestListServersBypassesProxy(t *testing.T) {
+	var proxyHits int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&proxyHits, 1)
+		http.Error(w, "should not be used", http.StatusTeapot)
+	}))
+	defer proxy.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+		case "/api/servers":
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+
+	setupCreds(t, srv.URL)
+	svs, err := ListServers(context.Background())
+	if err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+	if len(svs) != 1 {
+		t.Fatalf("len=%d, want 1", len(svs))
+	}
+	if atomic.LoadInt32(&proxyHits) != 0 {
+		t.Fatalf("proxy saw %d requests", proxyHits)
+	}
+}
+
+func TestListServersTelemetry(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Logger
+	log.Logger = log.Output(zerolog.SyncWriter(&buf))
+	t.Cleanup(func() { log.Logger = prev })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth2/token":
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+		case "/api/servers":
+			fmt.Fprint(w, `{"paging":{"page":1,"size":1,"total":1,"next":""},"servers":[{"id":"1","name":"One"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	setupCreds(t, srv.URL)
+	old := serverTTL
+	serverTTL = 50 * time.Millisecond
+	t.Cleanup(func() { serverTTL = old })
+
+	ctx := context.Background()
+
+	if _, err := ListServers(ctx); err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\"resource\":\"pufferpanel.servers\"") || !strings.Contains(out, "\"deduped\":\"false\"") ||
+		!strings.Contains(out, "\"cache_hit\":\"false\"") || !strings.Contains(out, "\"status\":\"ok\"") ||
+		!strings.Contains(out, "\"duration_ms\"") {
+		t.Fatalf("missing fields: %s", out)
+	}
+
+	buf.Reset()
+	serverCache = sync.Map{}
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := ListServers(ctx); err != nil {
+				t.Errorf("ListServers: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	out = buf.String()
+	if !strings.Contains(out, "\"deduped\":\"true\"") {
+		t.Fatalf("expected deduped true: %s", out)
+	}
+
+	buf.Reset()
+	if _, err := ListServers(ctx); err != nil {
+		t.Fatalf("ListServers cache: %v", err)
+	}
+	out = buf.String()
+	if !strings.Contains(out, "\"cache_hit\":\"true\"") {
+		t.Fatalf("expected cache hit: %s", out)
 	}
 }

--- a/internal/pufferpanel/token.go
+++ b/internal/pufferpanel/token.go
@@ -38,7 +38,7 @@ func fetchToken(ctx context.Context, c Credentials) (string, time.Time, error) {
 		return "", time.Time{}, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := newClient(u)
 	status, body, err := doRequest(ctx, client, req)
 	if err != nil {
 		return "", time.Time{}, err


### PR DESCRIPTION
## Summary
- avoid duplicate ListServers calls by de-duplicating requests per normalized PufferPanel base URL
- ensure ListServers calls are deduped even under heavy concurrency
- cache successful server listings for a short 2s window to sidestep redundant upstream requests
- map upstream 400/401/403 responses to bad_request/unauthorized/forbidden with actionable hints
- normalize and persist PufferPanel base URLs, rejecting unsupported schemes and stripping trailing slashes
- add regression tests ensuring absolute paging.next links and 302 redirects are rewritten to the base host
- verify proxy settings are ignored by confirming a fake HTTP_PROXY sees no traffic during server listing
- add regression test confirming cached server listings coalesce concurrent requests and refetch only after TTL expiry
- emit telemetry for every server listing, recording resource, status, duration, deduped, and cache hit

## Testing
- `go test ./...`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a8cb373c83219edd4ba8a660362b