### PR TITLE
feat: add server-side sync endpoint

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -31,7 +31,7 @@ describe("proxy API calls", () => {
     expect(String(opts.body)).not.toContain("token");
   });
 
-  it("does not send tokens when listing PufferPanel servers", async () => {
+  it("sends token when listing PufferPanel servers", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify([]), {
         status: 200,
@@ -45,55 +45,87 @@ describe("proxy API calls", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, opts] = fetchMock.mock.calls[0];
-    expect(url).toBe("/api/pufferpanel/servers");
-    expect(opts?.headers?.Authorization).toBeUndefined();
+    expect(url).toBe("/api/instances/sync");
+    expect(opts?.method).toBe("POST");
+    expect(opts?.headers?.Authorization).toBe("Bearer admintok");
+    expect(opts?.credentials).toBe("same-origin");
   });
 });
 
-describe('safe JSON parsing', () => {
+describe("safe JSON parsing", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('handles empty success body', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200, headers: { 'Content-Type': 'application/json' } }))); 
-    // @ts-ignore
-    await expect(getPufferServers()).resolves.toBeUndefined();
-  });
-
-  it('handles invalid json success body', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('oops', { status: 200, headers: { 'Content-Type': 'application/json' } }))); 
-    // @ts-ignore
-    await expect(getPufferServers()).resolves.toBeUndefined();
-  });
-
-  it('handles empty error body', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 400 }))); 
-    // @ts-ignore
-    await expect(getPufferServers()).rejects.toThrow('400');
-  });
-
-  it('handles non-json error body', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('oops', { status: 500 })));
-    // @ts-ignore
-    await expect(getPufferServers()).rejects.toThrow('500 oops');
-  });
-
-  it('uses server message and request id', async () => {
+  it("handles empty success body", async () => {
     vi.stubGlobal(
-      'fetch',
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(null, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+    // @ts-ignore
+    await expect(getPufferServers()).resolves.toBeUndefined();
+  });
+
+  it("handles invalid json success body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response("oops", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+    );
+    // @ts-ignore
+    await expect(getPufferServers()).resolves.toBeUndefined();
+  });
+
+  it("handles empty error body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 400 })),
+    );
+    // @ts-ignore
+    await expect(getPufferServers()).rejects.toThrow("400");
+  });
+
+  it("handles non-json error body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("oops", { status: 500 })),
+    );
+    // @ts-ignore
+    await expect(getPufferServers()).rejects.toThrow("500 oops");
+  });
+
+  it("uses server message and request id", async () => {
+    vi.stubGlobal(
+      "fetch",
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
-            code: 'bad_request',
-            message: 'bad',
-            requestId: 'abc123',
+            code: "bad_request",
+            message: "bad",
+            requestId: "abc123",
           }),
-          { status: 400, headers: { 'Content-Type': 'application/json' } },
+          { status: 400, headers: { "Content-Type": "application/json" } },
         ),
       ),
     );
     // @ts-ignore
-    await expect(getPufferServers()).rejects.toThrow('bad (request abc123)');
+    await getPufferServers().catch((err) => {
+      expect(err.message).toBe("bad");
+      // @ts-ignore
+      expect(err.requestId).toBe("abc123");
+    });
   });
 });

--- a/frontend/src/pages/InstancesSyncRoute.test.jsx
+++ b/frontend/src/pages/InstancesSyncRoute.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi } from "vitest";
+const navigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => navigate };
+});
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("@/lib/api.ts", async () => {
+  const actual = await vi.importActual("@/lib/api.ts");
+  return {
+    ...actual,
+    getInstances: vi.fn(),
+    addInstance: vi.fn(),
+    updateInstance: vi.fn(),
+    deleteInstance: vi.fn(),
+    getSecretStatus: vi.fn(),
+    getMods: vi.fn(),
+    // use real getPufferServers
+  };
+});
+
+vi.mock("focus-trap-react", () => ({
+  default: ({ children }) => children,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import Instances from "./Instances.jsx";
+import { getInstances, getSecretStatus } from "@/lib/api.ts";
+
+describe("Instances PufferPanel fetch", () => {
+  it("fetches servers via /api/instances/sync", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const origFetch = global.fetch;
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    getInstances.mockResolvedValueOnce([]);
+    getSecretStatus.mockResolvedValue({
+      exists: true,
+      last4: "1234",
+      updated_at: "",
+    });
+
+    render(
+      <MemoryRouter>
+        <Instances />
+      </MemoryRouter>,
+    );
+
+    const addBtn = await screen.findByRole("button", { name: /add instance/i });
+    fireEvent.click(addBtn);
+    const toggle = await screen.findByLabelText("Sync from PufferPanel");
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain("/api/instances/sync");
+    expect(urls.some((u) => u.startsWith("/api/pufferpanel/"))).toBe(false);
+
+    // @ts-ignore
+    global.fetch = origFetch;
+  });
+});

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -11,13 +11,7 @@ import { Select } from "@/components/ui/Select.jsx";
 import { Input } from "@/components/ui/Input.jsx";
 import { Button } from "@/components/ui/Button.jsx";
 import { Checkbox } from "@/components/ui/Checkbox.jsx";
-import {
-  getSecretStatus,
-  saveSecret,
-  clearSecret,
-  getPufferCreds,
-  testPufferCreds,
-} from "@/lib/api.ts";
+import { getSecretStatus, saveSecret, clearSecret } from "@/lib/api.ts";
 
 export default function Settings() {
   const { theme, setTheme, interval, setInterval } = usePreferences();
@@ -38,13 +32,6 @@ export default function Settings() {
       .then((s) => {
         setHasToken(s.exists);
         setTokenLast4(s.last4);
-      })
-      .catch(() => {});
-    getPufferCreds()
-      .then((c) => {
-        setBaseUrl(c.base_url || "");
-        setClientId(c.client_id || "");
-        setDeepScan(!!c.deep_scan);
       })
       .catch(() => {});
     getSecretStatus("pufferpanel")
@@ -123,20 +110,6 @@ export default function Settings() {
       toast.error(
         err instanceof Error ? err.message : "Failed to clear credentials",
       );
-    }
-  }
-
-  async function handlePufferTest() {
-    try {
-      await testPufferCreds({
-        base_url: baseUrl,
-        client_id: clientId,
-        client_secret: clientSecret,
-        deep_scan: deepScan,
-      });
-      toast.success("Connection successful");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Connection failed");
     }
   }
 
@@ -308,13 +281,6 @@ export default function Settings() {
               disabled={!hasPuffer}
             >
               Revoke & Clear
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={handlePufferTest}
-              disabled={!baseUrl || !clientId || !clientSecret}
-            >
-              Test
             </Button>
           </div>
         </CardContent>

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -8,10 +8,6 @@ vi.mock("@/lib/api.ts", () => ({
     .mockResolvedValue({ exists: false, last4: "", updated_at: "" }),
   saveSecret: vi.fn(),
   clearSecret: vi.fn(),
-  getPufferCreds: vi
-    .fn()
-    .mockResolvedValue({ base_url: "", client_id: "", client_secret: "" }),
-  testPufferCreds: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -24,7 +20,7 @@ vi.mock("focus-trap-react", () => ({
 
 import { MemoryRouter } from "react-router-dom";
 import Settings from "./Settings.jsx";
-import { saveSecret, clearSecret, testPufferCreds } from "@/lib/api.ts";
+import { saveSecret, clearSecret } from "@/lib/api.ts";
 import { toast } from "sonner";
 
 Object.defineProperty(window, "matchMedia", {
@@ -37,7 +33,7 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 describe("Settings page", () => {
-  it("saves, clears and tests PufferPanel credentials", async () => {
+  it("saves and clears PufferPanel credentials", async () => {
     const { getSecretStatus } = await import("@/lib/api.ts");
     getSecretStatus
       .mockResolvedValueOnce({ exists: false, last4: "", updated_at: "" }) // modrinth
@@ -61,15 +57,6 @@ describe("Settings page", () => {
       target: { value: "secret" },
     });
     fireEvent.click(screen.getByLabelText("Enable deep scan"));
-    const testBtn = screen.getByRole("button", { name: "Test" });
-    fireEvent.click(testBtn);
-    expect(testPufferCreds).toHaveBeenCalledWith({
-      base_url: "http://example.com",
-      client_id: "id",
-      client_secret: "secret",
-      deep_scan: true,
-    });
-
     const saveBtn = screen.getAllByRole("button", { name: "Save" })[1];
     fireEvent.click(saveBtn);
     await waitFor(() => expect(saveSecret).toHaveBeenCalled());

--- a/internal/pufferpanel/http.go
+++ b/internal/pufferpanel/http.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -22,6 +23,7 @@ func doRequest(ctx context.Context, client *http.Client, req *http.Request) (int
 	if len(logBody) > 1024 {
 		logBody = logBody[:1024]
 	}
+	logBody = urlRE.ReplaceAll(logBody, []byte("[redacted]"))
 	log.Ctx(ctx).Info().
 		Str("requestId", requestIDFromContext(ctx)).
 		Int("upstream_code", resp.StatusCode).
@@ -29,6 +31,8 @@ func doRequest(ctx context.Context, client *http.Client, req *http.Request) (int
 		Msg("pufferpanel response")
 	return resp.StatusCode, body, err
 }
+
+var urlRE = regexp.MustCompile(`https?://[^"\s]+`)
 
 // newClient creates an HTTP client that rewrites redirect destinations to the base host.
 func newClient(base *url.URL) *http.Client {

--- a/internal/pufferpanel/http_test.go
+++ b/internal/pufferpanel/http_test.go
@@ -1,10 +1,18 @@
 package pufferpanel
 
 import (
+	"bytes"
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 func TestNewClientTimeouts(t *testing.T) {
@@ -28,5 +36,108 @@ func TestNewClientTimeouts(t *testing.T) {
 	}
 	if tr.ExpectContinueTimeout != 1*time.Second {
 		t.Fatalf("ExpectContinueTimeout = %v, want 1s", tr.ExpectContinueTimeout)
+	}
+}
+
+func TestDoRequestRedactsHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"next":"https://example.com/api"}`))
+	}))
+	defer srv.Close()
+
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	client := newClient(base)
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+
+	var buf bytes.Buffer
+	old := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() { log.Logger = old }()
+
+	if _, _, err := doRequest(context.Background(), client, req); err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	if strings.Contains(buf.String(), "example.com") {
+		t.Fatalf("log contains host: %s", buf.String())
+	}
+}
+
+func TestNewClientRedirectRewritesHost(t *testing.T) {
+	var externalCalled atomic.Bool
+	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		externalCalled.Store(true)
+		t.Fatalf("external host contacted: %s", r.URL.String())
+	}))
+	defer external.Close()
+
+	base := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, external.URL+"/next", http.StatusFound)
+			return
+		}
+		if r.URL.Path == "/next" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		t.Fatalf("unexpected path: %s", r.URL.Path)
+	}))
+	defer base.Close()
+
+	u, err := url.Parse(base.URL)
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	client := newClient(u)
+	resp, err := client.Get(base.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+	if externalCalled.Load() {
+		t.Fatalf("external host was contacted")
+	}
+}
+
+func TestNewClientIgnoresProxy(t *testing.T) {
+	var proxyCalled atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyCalled.Store(true)
+		t.Fatalf("proxy was used for %s", r.URL.String())
+	}))
+	defer proxy.Close()
+
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+
+	baseCalled := atomic.Bool{}
+	base := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseCalled.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer base.Close()
+
+	u, err := url.Parse(base.URL)
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	client := newClient(u)
+	resp, err := client.Get(base.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	resp.Body.Close()
+	if proxyCalled.Load() {
+		t.Fatalf("proxy server was contacted")
+	}
+	if !baseCalled.Load() {
+		t.Fatalf("base server was not contacted")
 	}
 }


### PR DESCRIPTION
## Summary
- add POST `/api/instances/sync` endpoint to proxy PufferPanel servers
- hide external hostnames in PufferPanel client logs
- adjust frontend API and tests to use new endpoint
- require authentication for instance sync
- remove legacy `/api/pufferpanel/servers` route and update tests
- drop remaining `/api/pufferpanel/*` routes and route syncing through authenticated `/api/instances/{id}/sync`
- cache instance sync responses for a few seconds to dedupe concurrent requests
- add tests ensuring PufferPanel client rewrites redirects and ignores env proxies
- surface mapped PufferPanel errors in UI with request IDs preserved for debugging
- log `instances_sync` telemetry with status, duration, dedupe, cache-hit, and upstream status
- add handler tests for upstream errors and timeouts plus a frontend integration test ensuring only `/api/instances/sync` is called

## Testing
- `go test ./...`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd5f3530832188cf337eb0d20c6b