### PR TITLE
Serve index.html for unknown routes

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1294,8 +1294,17 @@ func serveStatic(static fs.FS) http.HandlerFunc {
 		}
 		data, err := fs.ReadFile(static, strings.TrimPrefix(path, "/"))
 		if err != nil {
-			http.NotFound(w, r)
-			return
+			if errors.Is(err, fs.ErrNotExist) {
+				data, err = fs.ReadFile(static, "index.html")
+				if err != nil {
+					http.NotFound(w, r)
+					return
+				}
+				path = "/index.html"
+			} else {
+				http.NotFound(w, r)
+				return
+			}
 		}
 		if path == "/index.html" {
 			if nonce, ok := r.Context().Value(nonceCtxKey{}).(string); ok && nonce != "" {


### PR DESCRIPTION
## Summary
- fallback static file handler to `index.html` when a direct SPA route is requested

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0582759fc83219c68658c30413b8b