### PR TITLE
Allow sync without body when server ID stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## Unreleased
 - enforce non-empty instance names with length checks (migration `002_instance_name_required`)
 - Fixed 404 on resync. /resync temporarily aliased to /sync.
+- Allow resyncing an instance without a request body when it already has a PufferPanel server ID.


### PR DESCRIPTION
## Summary
- allow `/api/instances/{id}/sync` to use stored PufferPanel server ID when no JSON body is provided
- add regression tests for sync handler and validation
- document the change in the changelog

## Testing
- `go test ./...`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05e279c9c83219aeb0be26dd14b65