### PR TITLE
Add explicit timeouts, connection pooling, and structured errors to Modrinth client

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,33 @@
+# Runbook
+
+## "context canceled"
+
+A Modrinth request may log an error similar to:
+
+```
+{"level":"info","event":"modrinth_error","error":"Get \"https://api.modrinth.com/v2/search?query=scalablelux\": context canceled"}
+```
+
+### Likely Causes
+- The client aborted the HTTP request (e.g., browser tab closed or navigation away).
+- The server shut down or the parent context was canceled, ending outstanding calls.
+- A timeout expired before the Modrinth request completed.
+
+### Step-by-Step Checks
+1. **Confirm the log entry**
+   - Search recent logs for `context canceled` to verify when and where it occurred.
+2. **Determine caller behaviour**
+   - Check whether the initiating client disconnected or canceled the request.
+   - Reproduce with a persistent client (e.g., `curl`) to rule out premature cancellation by the caller.
+3. **Inspect timeouts and shutdowns**
+   - Ensure server timeouts are sufficiently long for typical Modrinth latency.
+   - Confirm the server or worker wasn't shutting down at the time of the error.
+4. **Check network stability**
+   - Look for signs of connectivity issues between the server and Modrinth.
+5. **Verify worker continuation**
+   - For background jobs, confirm they continue processing despite the canceled request by checking job status and progress.
+
+### Resolution
+- If user cancellations are expected, no action is required.
+- For repeated unexpected cancellations, adjust timeouts, investigate network issues, or review shutdown procedures to ensure requests complete.
+

--- a/internal/db/mod_sync_state_test.go
+++ b/internal/db/mod_sync_state_test.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+    "database/sql"
+    "testing"
+)
+
+func TestSetModSyncState(t *testing.T) {
+    db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+    if err != nil {
+        t.Fatalf("open db: %v", err)
+    }
+    defer db.Close()
+    if err := Init(db); err != nil {
+        t.Fatalf("init: %v", err)
+    }
+    if err := Migrate(db); err != nil {
+        t.Fatalf("migrate: %v", err)
+    }
+    inst := &Instance{Name: "i"}
+    if err := InsertInstance(db, inst); err != nil {
+        t.Fatalf("insert inst: %v", err)
+    }
+    if err := SetModSyncState(db, inst.ID, "slug", "1.0.0", "failed"); err != nil {
+        t.Fatalf("set state: %v", err)
+    }
+    states, err := ListModSyncStates(db, inst.ID)
+    if err != nil {
+        t.Fatalf("list states: %v", err)
+    }
+    if len(states) != 1 {
+        t.Fatalf("got %d states want 1", len(states))
+    }
+    if states[0].Status != "failed" || states[0].LastVersion != "1.0.0" || states[0].Slug != "slug" {
+        t.Fatalf("unexpected state: %#v", states[0])
+    }
+    // Update
+    if err := SetModSyncState(db, inst.ID, "slug", "1.1.0", "succeeded"); err != nil {
+        t.Fatalf("set state2: %v", err)
+    }
+    states, err = ListModSyncStates(db, inst.ID)
+    if err != nil {
+        t.Fatalf("list states2: %v", err)
+    }
+    if len(states) != 1 {
+        t.Fatalf("got %d states want 1", len(states))
+    }
+    if states[0].Status != "succeeded" || states[0].LastVersion != "1.1.0" {
+        t.Fatalf("unexpected state after update: %#v", states[0])
+    }
+    if states[0].LastChecked == "" {
+        t.Fatalf("expected last_checked to be set")
+    }
+}
+

--- a/internal/handlers/jobs.go
+++ b/internal/handlers/jobs.go
@@ -1,0 +1,340 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	dbpkg "modsentinel/internal/db"
+	"modsentinel/internal/telemetry"
+)
+
+const (
+	JobQueued    = "queued"
+	JobRunning   = "running"
+	JobSucceeded = "succeeded"
+	JobFailed    = "failed"
+	JobCanceled  = "canceled"
+)
+
+var (
+	jobsCh  chan int
+	waiters sync.Map // map[int]chan struct{}
+	jobDB   *sql.DB
+
+	perInstLimit = 4
+	globalLimit  = 16
+
+	instMu    sync.Mutex
+	instSems  map[int]chan struct{}
+	globalSem chan struct{}
+
+	syncFn func(ctx context.Context, w http.ResponseWriter, r *http.Request, db *sql.DB, inst *dbpkg.Instance, serverID string, prog *jobProgress, files []string) = performSync
+
+	runWg  sync.WaitGroup
+	active int64
+
+	jobCancels sync.Map // map[int]context.CancelFunc
+	progress   sync.Map // map[int]*jobProgress
+	retryFiles sync.Map // map[int][]string
+)
+
+const maxFailures = 5
+
+type jobFailure struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+type jobProgress struct {
+	mu        sync.Mutex
+	total     int
+	processed int
+	succeeded int
+	failed    int
+	status    string
+	failures  []jobFailure
+	subs      map[chan struct{}]struct{}
+}
+
+func (p *jobProgress) setTotal(n int) {
+	p.mu.Lock()
+	p.total = n
+	p.notifyLocked()
+	p.mu.Unlock()
+}
+
+func (p *jobProgress) success() {
+	p.mu.Lock()
+	p.processed++
+	p.succeeded++
+	p.notifyLocked()
+	p.mu.Unlock()
+}
+
+func (p *jobProgress) fail(name string, err error) {
+	p.mu.Lock()
+	p.processed++
+	p.failed++
+	if len(p.failures) >= maxFailures {
+		copy(p.failures, p.failures[1:])
+		p.failures = p.failures[:maxFailures-1]
+	}
+	p.failures = append(p.failures, jobFailure{Name: name, Error: err.Error()})
+	p.notifyLocked()
+	p.mu.Unlock()
+}
+
+func (p *jobProgress) setStatus(s string) {
+	p.mu.Lock()
+	p.status = s
+	p.notifyLocked()
+	p.mu.Unlock()
+}
+
+func (p *jobProgress) subscribe() chan struct{} {
+	ch := make(chan struct{}, 1)
+	p.mu.Lock()
+	if p.subs == nil {
+		p.subs = make(map[chan struct{}]struct{})
+	}
+	p.subs[ch] = struct{}{}
+	p.mu.Unlock()
+	return ch
+}
+
+func (p *jobProgress) unsubscribe(ch chan struct{}) {
+	p.mu.Lock()
+	delete(p.subs, ch)
+	p.mu.Unlock()
+}
+
+func (p *jobProgress) notifyLocked() {
+	for ch := range p.subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (p *jobProgress) snapshot() (total, processed, succeeded, failed int, fails []jobFailure, status string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fails = append([]jobFailure(nil), p.failures...)
+	return p.total, p.processed, p.succeeded, p.failed, fails, p.status
+}
+
+func newJobProgress() *jobProgress {
+	return &jobProgress{subs: make(map[chan struct{}]struct{}), failures: make([]jobFailure, 0, maxFailures)}
+}
+
+func recordQueueMetrics() {
+	telemetry.Event("sync_queue", map[string]string{
+		"depth":  strconv.Itoa(len(jobsCh)),
+		"active": strconv.FormatInt(atomic.LoadInt64(&active), 10),
+	})
+}
+
+// StartJobQueue launches the background worker and enqueues pending jobs.
+// It returns a shutdown function that waits for in-flight jobs to finish or
+// requeue them if the provided context is canceled while waiting.
+func StartJobQueue(ctx context.Context, db *sql.DB) func(context.Context) {
+	jobDB = db
+	jobsCh = make(chan int, 16)
+	instSems = make(map[int]chan struct{})
+	globalSem = make(chan struct{}, globalLimit)
+	runCtx, cancel := context.WithCancel(ctx)
+	runWg.Add(1)
+	go worker(runCtx)
+	if err := dbpkg.ResetRunningSyncJobs(db); err == nil {
+		ids, err := dbpkg.ListQueuedSyncJobs(db)
+		if err == nil {
+			for _, id := range ids {
+				p := newJobProgress()
+				p.setStatus(JobQueued)
+				progress.Store(id, p)
+				jobsCh <- id
+			}
+		}
+	}
+	return func(waitCtx context.Context) {
+		cancel()
+		close(jobsCh)
+		done := make(chan struct{})
+		go func() {
+			runWg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-waitCtx.Done():
+			_ = dbpkg.ResetRunningSyncJobs(jobDB)
+		}
+	}
+}
+
+// EnqueueSync schedules a sync job for the given instance/server.
+// Duplicate requests with the same idempotency key return the existing job.
+func EnqueueSync(ctx context.Context, db *sql.DB, inst *dbpkg.Instance, serverID, key string) (int, <-chan struct{}, error) {
+	id, existed, err := dbpkg.InsertSyncJob(db, inst.ID, serverID, key)
+	if err != nil {
+		return 0, nil, err
+	}
+	if existed {
+		if ch, ok := waiters.Load(id); ok {
+			return id, ch.(chan struct{}), nil
+		}
+		ch := make(chan struct{})
+		waiters.Store(id, ch)
+		return id, ch, nil
+	}
+	ch := make(chan struct{})
+	waiters.Store(id, ch)
+	p := newJobProgress()
+	p.setStatus(JobQueued)
+	progress.Store(id, p)
+	jobsCh <- id
+	recordQueueMetrics()
+	return id, ch, nil
+}
+
+func worker(ctx context.Context) {
+	defer runWg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case id, ok := <-jobsCh:
+			if !ok {
+				return
+			}
+			recordQueueMetrics()
+			job, err := dbpkg.GetSyncJob(jobDB, id)
+			if err != nil {
+				_ = dbpkg.MarkSyncJobFinished(jobDB, id, JobFailed, err.Error())
+				if ch, ok := waiters.Load(id); ok {
+					close(ch.(chan struct{}))
+					waiters.Delete(id)
+				}
+				continue
+			}
+			if job.Status != JobQueued {
+				if ch, ok := waiters.Load(id); ok {
+					close(ch.(chan struct{}))
+					waiters.Delete(id)
+				}
+				continue
+			}
+			runWg.Add(1)
+			go func(job *dbpkg.SyncJob) {
+				defer runWg.Done()
+				acquire(job.InstanceID)
+				atomic.AddInt64(&active, 1)
+				recordQueueMetrics()
+				defer func() {
+					atomic.AddInt64(&active, -1)
+					recordQueueMetrics()
+				}()
+				defer release(job.InstanceID)
+				runJob(ctx, job)
+			}(job)
+		}
+	}
+}
+
+func acquire(instID int) {
+	globalSem <- struct{}{}
+	instMu.Lock()
+	sem, ok := instSems[instID]
+	if !ok {
+		sem = make(chan struct{}, perInstLimit)
+		instSems[instID] = sem
+	}
+	instMu.Unlock()
+	sem <- struct{}{}
+}
+
+func release(instID int) {
+	instMu.Lock()
+	sem := instSems[instID]
+	<-sem
+	if len(sem) == 0 {
+		delete(instSems, instID)
+	}
+	instMu.Unlock()
+	<-globalSem
+}
+
+func runJob(ctx context.Context, job *dbpkg.SyncJob) {
+	_ = dbpkg.MarkSyncJobRunning(jobDB, job.ID)
+	inst, err := dbpkg.GetInstance(jobDB, job.InstanceID)
+	if err != nil {
+		_ = dbpkg.MarkSyncJobFinished(jobDB, job.ID, JobFailed, err.Error())
+		if ch, ok := waiters.Load(job.ID); ok {
+			close(ch.(chan struct{}))
+			waiters.Delete(job.ID)
+		}
+		return
+	}
+	baseCtx := context.WithoutCancel(ctx)
+	jobCtx, cancel := context.WithCancel(baseCtx)
+	jobCancels.Store(job.ID, cancel)
+	defer jobCancels.Delete(job.ID)
+	jw := &jobWriter{}
+	req := &http.Request{Method: http.MethodPost, URL: &url.URL{Path: "/"}, Header: make(http.Header)}
+	req = req.WithContext(jobCtx)
+	p, _ := progress.LoadOrStore(job.ID, newJobProgress())
+	jp := p.(*jobProgress)
+	jp.setStatus(JobRunning)
+	var names []string
+	if v, ok := retryFiles.Load(job.ID); ok {
+		names = v.([]string)
+		retryFiles.Delete(job.ID)
+	}
+	syncFn(jobCtx, jw, req, jobDB, inst, job.ServerID, jp, names)
+	status := JobSucceeded
+	errMsg := ""
+	switch {
+	case jobCtx.Err() != nil:
+		status = JobCanceled
+	case jw.status >= 400:
+		status = JobFailed
+		errMsg = jw.buf.String()
+	}
+	_ = dbpkg.MarkSyncJobFinished(jobDB, job.ID, status, errMsg)
+	jp.setStatus(status)
+	if ch, ok := waiters.Load(job.ID); ok {
+		close(ch.(chan struct{}))
+		waiters.Delete(job.ID)
+	}
+}
+
+type jobWriter struct {
+	header http.Header
+	status int
+	buf    bytes.Buffer
+}
+
+func (jw *jobWriter) Header() http.Header {
+	if jw.header == nil {
+		jw.header = make(http.Header)
+	}
+	return jw.header
+}
+
+func (jw *jobWriter) Write(b []byte) (int, error) {
+	if jw.status == 0 {
+		jw.status = http.StatusOK
+	}
+	return jw.buf.Write(b)
+}
+
+func (jw *jobWriter) WriteHeader(code int) {
+	jw.status = code
+}

--- a/internal/handlers/jobs_test.go
+++ b/internal/handlers/jobs_test.go
@@ -1,0 +1,187 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	dbpkg "modsentinel/internal/db"
+	"modsentinel/internal/logx"
+	"strings"
+)
+
+func TestJobQueue_ShutdownWaitsForJobs(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	if err := dbpkg.Migrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	stop := StartJobQueue(context.Background(), db)
+	stopped := false
+	defer func() {
+		if !stopped {
+			stop(context.Background())
+		}
+		db.Close()
+	}()
+
+	inst := &dbpkg.Instance{Name: "A", Loader: "fabric"}
+	if err := dbpkg.InsertInstance(db, inst); err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
+
+	old := syncFn
+	syncFn = func(ctx context.Context, w http.ResponseWriter, r *http.Request, db *sql.DB, inst *dbpkg.Instance, serverID string, prog *jobProgress, files []string) {
+		time.Sleep(100 * time.Millisecond)
+	}
+	defer func() { syncFn = old }()
+
+	id, _, err := EnqueueSync(context.Background(), db, inst, "", "k1")
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		job, err := dbpkg.GetSyncJob(db, id)
+		if err != nil {
+			t.Fatalf("get job: %v", err)
+		}
+		if job.Status == JobRunning {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	start := time.Now()
+	stop(context.Background())
+	stopped = true
+	if time.Since(start) < 80*time.Millisecond {
+		t.Fatalf("stop returned too quickly")
+	}
+	job, err := dbpkg.GetSyncJob(db, id)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if job.Status != JobSucceeded {
+		t.Fatalf("got status %s want %s", job.Status, JobSucceeded)
+	}
+}
+
+func TestEnqueueSync_DedupesByKey(t *testing.T) {
+	db := openTestDB(t)
+	inst := &dbpkg.Instance{Name: "i"}
+	if err := dbpkg.InsertInstance(db, inst); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	orig := syncFn
+	syncFn = func(ctx context.Context, w http.ResponseWriter, r *http.Request, db *sql.DB, inst *dbpkg.Instance, serverID string, prog *jobProgress, files []string) {
+	}
+	t.Cleanup(func() { syncFn = orig })
+	id1, _, err := EnqueueSync(context.Background(), db, inst, "srv", "key")
+	if err != nil {
+		t.Fatalf("enqueue1: %v", err)
+	}
+	id2, _, err := EnqueueSync(context.Background(), db, inst, "srv", "key")
+	if err != nil {
+		t.Fatalf("enqueue2: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("ids differ %d vs %d", id1, id2)
+	}
+	var c int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sync_jobs`).Scan(&c); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if c != 1 {
+		t.Fatalf("got %d jobs want 1", c)
+	}
+}
+
+func TestQueueMetricsEmitted(t *testing.T) {
+	db := openTestDB(t)
+	inst := &dbpkg.Instance{Name: "i"}
+	if err := dbpkg.InsertInstance(db, inst); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(logx.NewRedactor(&buf)).With().Timestamp().Logger()
+	origSync := syncFn
+	syncFn = func(ctx context.Context, w http.ResponseWriter, r *http.Request, db *sql.DB, inst *dbpkg.Instance, serverID string, prog *jobProgress, files []string) {
+	}
+	id, ch, err := EnqueueSync(context.Background(), db, inst, "", "k")
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	// Wait for job to finish to avoid leaking goroutines.
+	<-ch
+	syncFn = origSync
+	if !strings.Contains(buf.String(), "\"event\":\"sync_queue\"") {
+		t.Fatalf("expected sync_queue metric, got %s", buf.String())
+	}
+	// ensure id used to avoid unused var warning
+	if id == 0 {
+		t.Fatalf("invalid id")
+	}
+}
+
+func TestRetryFailedEnqueuesOnlyFailures(t *testing.T) {
+	db := openTestDB(t)
+	inst := &dbpkg.Instance{Name: "i"}
+	if err := dbpkg.InsertInstance(db, inst); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	res, err := db.Exec(`INSERT INTO sync_jobs(instance_id, server_id, status, idempotency_key) VALUES(?, '', 'succeeded', 'k')`, inst.ID)
+	if err != nil {
+		t.Fatalf("insert job: %v", err)
+	}
+	jid64, _ := res.LastInsertId()
+	id := int(jid64)
+	jp := newJobProgress()
+	jp.fail("a", errors.New("boom"))
+	jp.fail("b", errors.New("boom"))
+	progress.Store(id, jp)
+	jobsCh = make(chan int, 1)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/jobs/%d/retry", id), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.Itoa(id))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	retryFailedHandler(db)(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	select {
+	case gotID := <-jobsCh:
+		if gotID != id {
+			t.Fatalf("enqueued %d want %d", gotID, id)
+		}
+	default:
+		t.Fatalf("job not enqueued")
+	}
+	v, ok := retryFiles.Load(id)
+	if !ok {
+		t.Fatalf("no retry files")
+	}
+	names := v.([]string)
+	if len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Fatalf("got %v", names)
+	}
+}

--- a/internal/modrinth/client.go
+++ b/internal/modrinth/client.go
@@ -6,81 +6,307 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
+	"net"
 	"net/http"
 	urlpkg "net/url"
+	"regexp"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
+	"unicode"
+
+	"golang.org/x/sync/singleflight"
 
 	"modsentinel/internal/telemetry"
 	tokenpkg "modsentinel/internal/token"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+const userAgent = "ModSentinel/1.0 (+https://github.com/nl2109/ModSentinel)"
+
 // Client wraps HTTP access to the Modrinth API.
 type Client struct {
-	http *http.Client
+	http    *http.Client
+	sf      singleflight.Group
+	ttl     time.Duration
+	cache   map[string]cacheEntry
+	mu      sync.Mutex
+	backoff time.Duration
+}
+
+type cacheEntry struct {
+	data []byte
+	exp  time.Time
 }
 
 // NewClient returns a Client with sane defaults.
 func NewClient() *Client {
-	return &Client{http: &http.Client{Timeout: 10 * time.Second}}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	transport.TLSHandshakeTimeout = 5 * time.Second
+	transport.ResponseHeaderTimeout = 10 * time.Second
+	transport.ExpectContinueTimeout = 1 * time.Second
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.MaxConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+
+	return &Client{
+		http:  &http.Client{Timeout: 30 * time.Second, Transport: transport},
+		ttl:   5 * time.Minute,
+		cache: make(map[string]cacheEntry),
+	}
 }
 
 // Error represents a normalized Modrinth API error.
+// Kind categorizes Modrinth errors.
+type Kind string
+
+const (
+	KindTimeout     Kind = "timeout"
+	KindCanceled    Kind = "canceled"
+	KindRateLimited Kind = "rate_limited"
+	KindServer      Kind = "server_error"
+	KindClient      Kind = "client_error"
+)
+
+// Error represents a normalized Modrinth API error.
 type Error struct {
+	Kind    Kind
 	Status  int
 	Message string
+	Err     error
 }
 
-func (e *Error) Error() string { return e.Message }
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "modrinth error"
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+// randDuration returns a random duration between 0 and max.
+// It is declared as a variable to allow tests to stub out randomness.
+var randDuration = func(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(max)))
+}
+
+// sleep is declared as a variable so tests can stub out actual sleeping.
+var sleep = time.Sleep
+
+func redactURL(u *urlpkg.URL) string {
+	cpy := *u
+	q := cpy.Query()
+	for _, k := range []string{"token", "key", "api_key"} {
+		if q.Has(k) {
+			q.Set(k, "REDACTED")
+		}
+	}
+	cpy.RawQuery = q.Encode()
+	return cpy.Redacted()
+}
 
 // do executes the request with retry/backoff and decodes JSON into v.
 func (c *Client) do(req *http.Request, v interface{}) error {
-	tok, _ := tokenpkg.GetToken()
-	if tok != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+	key := req.Method + " " + req.URL.String()
+	if c.ttl > 0 {
+		c.mu.Lock()
+		if e, ok := c.cache[key]; ok {
+			if time.Now().Before(e.exp) {
+				data := e.data
+				c.mu.Unlock()
+				if v != nil {
+					if err := json.Unmarshal(data, v); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+			delete(c.cache, key)
+		}
+		c.mu.Unlock()
 	}
-	req.Header.Set("User-Agent", "ModSentinel/1.0")
-	var resp *http.Response
-	var err error
-	for i := 0; i < 3; i++ {
-		resp, err = c.http.Do(req)
+	data, err, _ := c.sf.Do(key, func() (interface{}, error) {
+		c.mu.Lock()
+		bo := c.backoff
+		c.mu.Unlock()
+		if bo > 0 {
+			sleep(bo + randDuration(bo))
+		}
+		tok, _ := tokenpkg.GetToken()
+		if tok != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
+		}
+		req.Header.Set("User-Agent", userAgent)
+		var resp *http.Response
+		var err error
+		var dur time.Duration
+		urlStr := redactURL(req.URL)
+		for i := 0; i < 3; i++ {
+			start := time.Now()
+			resp, err = c.http.Do(req)
+			dur = time.Since(start)
+			attempt := strconv.Itoa(i + 1)
+			if err != nil {
+				telemetry.Event("modrinth_request", map[string]string{
+					"method":      req.Method,
+					"url":         urlStr,
+					"status":      "error",
+					"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+					"attempt":     attempt,
+				})
+				telemetry.Event("modrinth_error", map[string]string{"error": err.Error()})
+				kind := KindClient
+				switch {
+				case errors.Is(err, context.Canceled):
+					kind = KindCanceled
+				case errors.Is(err, context.DeadlineExceeded):
+					kind = KindTimeout
+				case func() bool {
+					ne, ok := err.(net.Error)
+					return ok && ne.Timeout()
+				}():
+					kind = KindTimeout
+				}
+				telemetry.Event("modrinth_result", map[string]string{
+					"outcome":     "error",
+					"kind":        string(kind),
+					"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+				})
+				return nil, &Error{Kind: kind, Err: err}
+			}
+			telemetry.Event("modrinth_request", map[string]string{
+				"method":      req.Method,
+				"url":         urlStr,
+				"status":      strconv.Itoa(resp.StatusCode),
+				"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+				"attempt":     attempt,
+			})
+			if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+				base := 250 * time.Millisecond
+				delay := time.Duration(1<<i) * base
+				if ra := resp.Header.Get("Retry-After"); ra != "" {
+					if secs, err := strconv.Atoi(ra); err == nil {
+						raDelay := time.Duration(secs) * time.Second
+						if raDelay > delay {
+							delay = raDelay
+						}
+					} else if t, err := http.ParseTime(ra); err == nil {
+						raDelay := time.Until(t)
+						if raDelay > delay {
+							delay = raDelay
+						}
+					}
+				}
+				j := randDuration(delay)
+				resp.Body.Close()
+				sleep(delay + j)
+				continue
+			}
+			break
+		}
+		if resp == nil {
+			telemetry.Event("modrinth_result", map[string]string{
+				"outcome":     "error",
+				"kind":        string(KindServer),
+				"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+			})
+			return nil, &Error{Kind: KindServer, Message: "no response"}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			telemetry.Event("modrinth_error", map[string]string{"status": strconv.Itoa(resp.StatusCode)})
+			kind := KindClient
+			if resp.StatusCode == http.StatusTooManyRequests {
+				kind = KindRateLimited
+				c.mu.Lock()
+				if c.backoff == 0 {
+					c.backoff = time.Second
+				} else {
+					c.backoff *= 2
+					if c.backoff > time.Minute {
+						c.backoff = time.Minute
+					}
+				}
+				c.mu.Unlock()
+			} else {
+				if resp.StatusCode >= 500 {
+					kind = KindServer
+				}
+				c.mu.Lock()
+				c.backoff = 0
+				c.mu.Unlock()
+			}
+			telemetry.Event("modrinth_result", map[string]string{
+				"outcome":     "error",
+				"kind":        string(kind),
+				"status":      strconv.Itoa(resp.StatusCode),
+				"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+			})
+			var apiErr struct {
+				Error       string `json:"error"`
+				Description string `json:"description"`
+			}
+			b, _ := io.ReadAll(resp.Body)
+			if err := json.Unmarshal(b, &apiErr); err == nil {
+				msg := apiErr.Description
+				if msg == "" {
+					msg = apiErr.Error
+				}
+				if msg != "" {
+					return nil, &Error{Kind: kind, Status: resp.StatusCode, Message: msg}
+				}
+			}
+			return nil, &Error{Kind: kind, Status: resp.StatusCode, Message: resp.Status}
+		}
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
-			telemetry.Event("modrinth_error", map[string]string{"error": err.Error()})
-			return err
+			telemetry.Event("modrinth_result", map[string]string{
+				"outcome":     "error",
+				"kind":        string(KindClient),
+				"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+			})
+			return nil, err
 		}
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			// retry with exponential backoff
-			delay := time.Duration(1<<i) * 250 * time.Millisecond
-			resp.Body.Close()
-			time.Sleep(delay)
-			continue
-		}
-		break
-	}
-	if resp == nil {
-		return errors.New("no response")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		telemetry.Event("modrinth_error", map[string]string{"status": strconv.Itoa(resp.StatusCode)})
-		var apiErr struct {
-			Error       string `json:"error"`
-			Description string `json:"description"`
-		}
-		b, _ := io.ReadAll(resp.Body)
-		if err := json.Unmarshal(b, &apiErr); err == nil {
-			msg := apiErr.Description
-			if msg == "" {
-				msg = apiErr.Error
+		if c.ttl > 0 {
+			c.mu.Lock()
+			if c.cache == nil {
+				c.cache = make(map[string]cacheEntry)
 			}
-			if msg != "" {
-				return &Error{Status: resp.StatusCode, Message: msg}
-			}
+			c.cache[key] = cacheEntry{data: b, exp: time.Now().Add(c.ttl)}
+			c.mu.Unlock()
 		}
-		return &Error{Status: resp.StatusCode, Message: resp.Status}
+		telemetry.Event("modrinth_result", map[string]string{
+			"outcome":     "success",
+			"status":      strconv.Itoa(resp.StatusCode),
+			"duration_ms": strconv.FormatInt(dur.Milliseconds(), 10),
+		})
+		c.mu.Lock()
+		c.backoff = 0
+		c.mu.Unlock()
+		return b, nil
+	})
+	if err != nil {
+		return err
 	}
 	if v != nil {
-		if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		if err := json.Unmarshal(data.([]byte), v); err != nil {
 			return err
 		}
 	}
@@ -155,8 +381,36 @@ type SearchResult struct {
 	} `json:"hits"`
 }
 
+// normalizeQuery trims whitespace, lowercases, and strips common version suffixes
+// like "-1.2.3" from the provided query.
+func normalizeQuery(q string) string {
+	q = strings.TrimSpace(strings.ToLower(q))
+	re := regexp.MustCompile(`[-_]?v?\d+(?:\.\d+){1,3}.*$`)
+	q = re.ReplaceAllString(q, "")
+	q = strings.Trim(q, "-_")
+	return q
+}
+
+// validateQuery ensures the normalized query is non-empty and free of
+// non-ASCII control characters.
+func validateQuery(q string) error {
+	if q == "" {
+		return errors.New("empty query")
+	}
+	for _, r := range q {
+		if unicode.IsControl(r) && r > unicode.MaxASCII {
+			return fmt.Errorf("invalid control character %U", r)
+		}
+	}
+	return nil
+}
+
 // Search performs a project search.
 func (c *Client) Search(ctx context.Context, query string) (*SearchResult, error) {
+	query = normalizeQuery(query)
+	if err := validateQuery(query); err != nil {
+		return nil, err
+	}
 	url := fmt.Sprintf("https://api.modrinth.com/v2/search?query=%s", urlpkg.QueryEscape(query))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -167,4 +421,29 @@ func (c *Client) Search(ctx context.Context, query string) (*SearchResult, error
 		return nil, err
 	}
 	return &res, nil
+}
+
+// Resolve fetches a project by slug, falling back to search when the slug is not found.
+func (c *Client) Resolve(ctx context.Context, slug string) (*Project, string, error) {
+	proj, err := c.Project(ctx, slug)
+	if err == nil {
+		return proj, slug, nil
+	}
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusNotFound {
+		return nil, "", err
+	}
+	res, err := c.Search(ctx, slug)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(res.Hits) == 0 {
+		return nil, "", &Error{Status: http.StatusNotFound, Message: "project not found"}
+	}
+	slug = res.Hits[0].Slug
+	proj, err = c.Project(ctx, slug)
+	if err != nil {
+		return nil, "", err
+	}
+	return proj, slug, nil
 }

--- a/internal/modrinth/client_test.go
+++ b/internal/modrinth/client_test.go
@@ -1,18 +1,63 @@
 package modrinth
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
 	dbpkg "modsentinel/internal/db"
+	logx "modsentinel/internal/logx"
 	"modsentinel/internal/secrets"
 	tokenpkg "modsentinel/internal/token"
 
 	_ "modernc.org/sqlite"
 )
+
+// Test that NewClient configures transport timeouts and connection pooling.
+func TestNewClientTransportConfig(t *testing.T) {
+	c := NewClient()
+	if c.http.Timeout != 30*time.Second {
+		t.Fatalf("Timeout = %v, want 30s", c.http.Timeout)
+	}
+	tr, ok := c.http.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *http.Transport", c.http.Transport)
+	}
+	if tr.TLSHandshakeTimeout != 5*time.Second {
+		t.Fatalf("TLSHandshakeTimeout = %v, want 5s", tr.TLSHandshakeTimeout)
+	}
+	if tr.ResponseHeaderTimeout != 10*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %v, want 10s", tr.ResponseHeaderTimeout)
+	}
+	if tr.ExpectContinueTimeout != 1*time.Second {
+		t.Fatalf("ExpectContinueTimeout = %v, want 1s", tr.ExpectContinueTimeout)
+	}
+	if tr.MaxIdleConns != 100 {
+		t.Fatalf("MaxIdleConns = %d, want 100", tr.MaxIdleConns)
+	}
+	if tr.MaxIdleConnsPerHost != 10 {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want 10", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxConnsPerHost != 10 {
+		t.Fatalf("MaxConnsPerHost = %d, want 10", tr.MaxConnsPerHost)
+	}
+	if tr.IdleConnTimeout != 90*time.Second {
+		t.Fatalf("IdleConnTimeout = %v, want 90s", tr.IdleConnTimeout)
+	}
+}
 
 // Test that the client attaches the Authorization header when a token exists.
 func TestClientAddsAuthorizationHeader(t *testing.T) {
@@ -87,6 +132,160 @@ func TestClientOmitsAuthorizationHeader(t *testing.T) {
 	}
 }
 
+// Test that the client sends the expected User-Agent.
+func TestClientSetsUserAgent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != userAgent {
+			t.Fatalf("User-Agent = %q want %q", got, userAgent)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+}
+
+// Test that request metadata is logged without leaking tokens.
+func TestClientLogsRequest(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	if err := dbpkg.Migrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	tokenpkg.Init(secrets.NewService(db))
+	const tok = "abcd1234"
+	if err := tokenpkg.SetToken(tok); err != nil {
+		t.Fatalf("set token: %v", err)
+	}
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(logx.NewRedactor(&buf)).With().Timestamp().Logger()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"?token=secret&key=apikey", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\"event\":\"modrinth_request\"") {
+		t.Fatalf("expected modrinth_request event, got %s", out)
+	}
+	if !strings.Contains(out, "\"method\":\"GET\"") {
+		t.Fatalf("expected method GET, got %s", out)
+	}
+	if !strings.Contains(out, "\"status\":\"200\"") {
+		t.Fatalf("expected status 200, got %s", out)
+	}
+	if !strings.Contains(out, "\"attempt\":\"1\"") {
+		t.Fatalf("expected attempt 1, got %s", out)
+	}
+	if strings.Contains(out, "secret") || strings.Contains(out, tok) {
+		t.Fatalf("log leaked token: %s", out)
+	}
+	if !strings.Contains(out, "token=REDACTED") || !strings.Contains(out, "key=REDACTED") {
+		t.Fatalf("expected redacted URL, got %s", out)
+	}
+}
+
+// Test that the client emits a success metric.
+func TestClientEmitsSuccessMetric(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	if err := dbpkg.Migrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	tokenpkg.Init(secrets.NewService(db))
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(logx.NewRedactor(&buf)).With().Timestamp().Logger()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\"event\":\"modrinth_result\"") || !strings.Contains(out, "\"outcome\":\"success\"") {
+		t.Fatalf("expected success metric, got %s", out)
+	}
+}
+
+// Test that the client emits an error metric with kind classification.
+func TestClientEmitsErrorMetric(t *testing.T) {
+	oldRand := randDuration
+	randDuration = func(d time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	oldSleep := sleep
+	sleep = func(time.Duration) {}
+	defer func() { sleep = oldSleep }()
+
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	if err := dbpkg.Migrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	tokenpkg.Init(secrets.NewService(db))
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(logx.NewRedactor(&buf)).With().Timestamp().Logger()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\"event\":\"modrinth_result\"") || !strings.Contains(out, "\"outcome\":\"error\"") || !strings.Contains(out, "\"kind\":\"server_error\"") {
+		t.Fatalf("expected error metric, got %s", out)
+	}
+}
+
 // Test that the client retries with exponential backoff on server errors.
 func TestClientBackoff(t *testing.T) {
 	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
@@ -118,15 +317,163 @@ func TestClientBackoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	start := time.Now()
+	oldRand := randDuration
+	randDuration = func(time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	var sleeps []time.Duration
+	oldSleep := sleep
+	sleep = func(d time.Duration) { sleeps = append(sleeps, d) }
+	defer func() { sleep = oldSleep }()
+
 	if err := c.do(req, &struct{}{}); err != nil {
 		t.Fatalf("do: %v", err)
 	}
 	if attempts != 3 {
 		t.Fatalf("expected 3 attempts, got %d", attempts)
 	}
-	if elapsed := time.Since(start); elapsed < 700*time.Millisecond {
-		t.Fatalf("expected backoff delay, got %v", elapsed)
+	want := []time.Duration{250 * time.Millisecond, 500 * time.Millisecond}
+	if !reflect.DeepEqual(sleeps, want) {
+		t.Fatalf("sleeps = %v want %v", sleeps, want)
+	}
+}
+
+// Test that the client retries on 429 responses with backoff and jitter.
+func TestClientBackoffTooManyRequests(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	if err := dbpkg.Migrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	tokenpkg.Init(secrets.NewService(db))
+	oldRand := randDuration
+	randDuration = func(time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	var sleeps []time.Duration
+	oldSleep := sleep
+	sleep = func(d time.Duration) { sleeps = append(sleeps, d) }
+	defer func() { sleep = oldSleep }()
+	attempts := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+	want := []time.Duration{250 * time.Millisecond, 500 * time.Millisecond}
+	if !reflect.DeepEqual(sleeps, want) {
+		t.Fatalf("sleeps = %v want %v", sleeps, want)
+	}
+}
+
+// Test that the client respects Retry-After headers for rate limiting.
+func TestClientRetryAfterHeader(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:memdb1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := dbpkg.Init(db); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	if err := dbpkg.Migrate(db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	tokenpkg.Init(secrets.NewService(db))
+	oldRand := randDuration
+	randDuration = func(d time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	var slept time.Duration
+	oldSleep := sleep
+	sleep = func(d time.Duration) { slept += d }
+	defer func() { sleep = oldSleep }()
+	attempts := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	if slept < 2*time.Second {
+		t.Fatalf("expected sleep at least 2s, got %v", slept)
+	}
+}
+
+// Test that repeated 429 responses escalate global backoff.
+func TestClientRateLimitEscalation(t *testing.T) {
+	oldRand := randDuration
+	randDuration = func(d time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	var sleeps []time.Duration
+	oldSleep := sleep
+	sleep = func(d time.Duration) { sleeps = append(sleeps, d) }
+	defer func() { sleep = oldSleep }()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+	c := &Client{http: ts.Client()}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if c.backoff != time.Second {
+		t.Fatalf("expected backoff 1s, got %v", c.backoff)
+	}
+	sleeps = nil
+	req2, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req2, &struct{}{}); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(sleeps) == 0 || sleeps[0] != time.Second {
+		t.Fatalf("expected initial sleep 1s, got %v", sleeps)
+	}
+	if c.backoff != 2*time.Second {
+		t.Fatalf("expected backoff 2s, got %v", c.backoff)
 	}
 }
 
@@ -169,5 +516,481 @@ func TestClientInvalidToken(t *testing.T) {
 		if me.Status != http.StatusUnauthorized {
 			t.Fatalf("status = %d want %d", me.Status, http.StatusUnauthorized)
 		}
+		if me.Kind != KindClient {
+			t.Fatalf("kind = %v want %v", me.Kind, KindClient)
+		}
+	}
+}
+
+func TestClientErrorClassificationHTTP(t *testing.T) {
+	oldRand := randDuration
+	randDuration = func(d time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	oldSleep := sleep
+	sleep = func(time.Duration) {}
+	defer func() { sleep = oldSleep }()
+	cases := []struct {
+		status int
+		kind   Kind
+	}{
+		{http.StatusTooManyRequests, KindRateLimited},
+		{http.StatusInternalServerError, KindServer},
+		{http.StatusNotFound, KindClient},
+	}
+	for _, tt := range cases {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tt.status)
+			w.Write([]byte(`{"error":"msg"}`))
+		}))
+		c := &Client{http: ts.Client()}
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		if err := c.do(req, &struct{}{}); err == nil {
+			t.Fatalf("expected error for status %d", tt.status)
+		} else if me, ok := err.(*Error); !ok {
+			t.Fatalf("unexpected error type: %T", err)
+		} else {
+			if me.Kind != tt.kind {
+				t.Fatalf("kind = %v want %v", me.Kind, tt.kind)
+			}
+			if me.Status != tt.status {
+				t.Fatalf("status = %d want %d", me.Status, tt.status)
+			}
+		}
+		ts.Close()
+	}
+}
+
+func TestClientErrorKindTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer ts.Close()
+	c := &Client{http: &http.Client{Timeout: 100 * time.Millisecond}}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err == nil {
+		t.Fatalf("expected timeout error")
+	} else if me, ok := err.(*Error); !ok {
+		t.Fatalf("unexpected error type: %T", err)
+	} else if me.Kind != KindTimeout {
+		t.Fatalf("kind = %v want %v", me.Kind, KindTimeout)
+	}
+}
+
+func TestClientErrorKindCanceled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+	c := &Client{http: ts.Client()}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err == nil {
+		t.Fatalf("expected canceled error")
+	} else if me, ok := err.(*Error); !ok {
+		t.Fatalf("unexpected error type: %T", err)
+	} else if me.Kind != KindCanceled {
+		t.Fatalf("kind = %v want %v", me.Kind, KindCanceled)
+	}
+}
+
+func TestNormalizeQuery(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"  FancyMod-1.2.3  ", "fancymod"},
+		{"Example_MOD-2.0", "example_mod"},
+		{"some_mod_1.18", "some_mod"},
+		{"Sodium", "sodium"},
+	}
+	for _, tt := range cases {
+		if got := normalizeQuery(tt.in); got != tt.want {
+			t.Errorf("normalizeQuery(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveProjectDirect(t *testing.T) {
+	paths := []string{}
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		if req.URL.Path != "/v2/project/sodium" {
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"title":"Sodium","icon_url":""}`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c := &Client{http: &http.Client{Transport: rt}}
+	proj, slug, err := c.Resolve(context.Background(), "sodium")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if slug != "sodium" {
+		t.Fatalf("slug = %q; want %q", slug, "sodium")
+	}
+	if proj.Title != "Sodium" {
+		t.Fatalf("title = %q; want %q", proj.Title, "Sodium")
+	}
+	if len(paths) != 1 || paths[0] != "/v2/project/sodium" {
+		t.Fatalf("paths = %v; want [/v2/project/sodium]", paths)
+	}
+}
+
+func TestResolveProjectSearchFallback(t *testing.T) {
+	paths := []string{}
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		paths = append(paths, req.URL.Path)
+		switch req.URL.Path {
+		case "/v2/project/foo":
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+				Header:     make(http.Header),
+			}, nil
+		case "/v2/search":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"hits":[{"project_id":"1","slug":"sodium","title":"Sodium"}]}`)),
+				Header:     make(http.Header),
+			}, nil
+		case "/v2/project/sodium":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"title":"Sodium","icon_url":""}`)),
+				Header:     make(http.Header),
+			}, nil
+		default:
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		return nil, nil
+	})
+	c := &Client{http: &http.Client{Transport: rt}}
+	proj, slug, err := c.Resolve(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if slug != "sodium" {
+		t.Fatalf("slug = %q; want %q", slug, "sodium")
+	}
+	if proj.Title != "Sodium" {
+		t.Fatalf("title = %q; want %q", proj.Title, "Sodium")
+	}
+	want := []string{"/v2/project/foo", "/v2/search", "/v2/project/sodium"}
+	if len(paths) != len(want) {
+		t.Fatalf("paths = %v; want %v", paths, want)
+	}
+	for i, p := range want {
+		if paths[i] != p {
+			t.Fatalf("paths[%d] = %s; want %s", i, paths[i], p)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestSearchNormalizesQuery(t *testing.T) {
+	var got string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query().Get("query")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"hits":[]}`))
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = u.Scheme
+		req.URL.Host = u.Host
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	c := &Client{http: &http.Client{Transport: rt}}
+	if _, err := c.Search(context.Background(), " MyMod-1.2.3 "); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if got != "mymod" {
+		t.Fatalf("query = %q, want %q", got, "mymod")
+	}
+}
+
+func TestSearchRejectsInvalidQuery(t *testing.T) {
+	c := NewClient()
+	if _, err := c.Search(context.Background(), "   "); err == nil {
+		t.Fatal("expected error for empty query")
+	}
+	bad := "mo" + string(rune(0x85)) + "d"
+	if _, err := c.Search(context.Background(), bad); err == nil {
+		t.Fatal("expected error for control character")
+	}
+}
+
+// Test that concurrent identical requests share a single underlying call.
+func TestClientSingleFlightDedupe(t *testing.T) {
+	var requests int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client()}
+	const goroutines = 5
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+			if err != nil {
+				t.Errorf("new request: %v", err)
+				return
+			}
+			if err := c.do(req, &struct{}{}); err != nil {
+				t.Errorf("do: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("expected 1 request, got %d", got)
+	}
+}
+
+// Test that successful responses are cached for the TTL duration.
+func TestClientCachesResponses(t *testing.T) {
+	var requests int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client(), ttl: time.Minute}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do 1: %v", err)
+	}
+
+	req2, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req2, &struct{}{}); err != nil {
+		t.Fatalf("do 2: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("expected 1 request, got %d", got)
+	}
+}
+
+// Test that cached entries expire after the TTL.
+func TestClientCacheTTL(t *testing.T) {
+	var requests int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client(), ttl: 10 * time.Millisecond}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req, &struct{}{}); err != nil {
+		t.Fatalf("do 1: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	req2, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req2, &struct{}{}); err != nil {
+		t.Fatalf("do 2: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Fatalf("expected 2 requests, got %d", got)
+	}
+}
+
+// Test that error responses are not cached.
+func TestClientDoesNotCacheErrors(t *testing.T) {
+	var requests int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requests, 1)
+		if n <= 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"fail"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	c := &Client{http: ts.Client(), ttl: time.Minute}
+
+	req1, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req1, &struct{}{}); err == nil {
+		t.Fatalf("expected error")
+	}
+
+	req2, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if err := c.do(req2, &struct{}{}); err != nil {
+		t.Fatalf("second request: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&requests); got != 4 {
+		t.Fatalf("expected 4 requests, got %d", got)
+	}
+}
+
+// Test that Search retries on server errors and eventually succeeds.
+func TestSearchRecoversFromServerError(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			resp := &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("{}")),
+			}
+			return resp, nil
+		}
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"hits":[{"slug":"ok"}]}`)),
+		}
+		return resp, nil
+	})
+	c := NewClient()
+	oldRand := randDuration
+	randDuration = func(time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	oldSleep := sleep
+	sleep = func(time.Duration) {}
+	defer func() { sleep = oldSleep }()
+	c.http = &http.Client{Transport: rt}
+	res, err := c.Search(context.Background(), "ok")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].Slug != "ok" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+// Test that Search retries on rate limits and succeeds.
+func TestSearchRecoversFromRateLimit(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			resp := &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+			}
+			return resp, nil
+		}
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"hits":[{"slug":"ok"}]}`)),
+		}
+		return resp, nil
+	})
+	c := NewClient()
+	oldRand := randDuration
+	randDuration = func(time.Duration) time.Duration { return 0 }
+	defer func() { randDuration = oldRand }()
+	oldSleep := sleep
+	sleep = func(time.Duration) {}
+	defer func() { sleep = oldSleep }()
+	c.http = &http.Client{Transport: rt}
+	res, err := c.Search(context.Background(), "ok")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].Slug != "ok" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+// Test that a timeout error does not prevent subsequent requests from succeeding.
+func TestSearchRecoversAfterTimeout(t *testing.T) {
+	var attempts int32
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"hits":[{"slug":"ok"}]}`)),
+		}
+		return resp, nil
+	})
+	c := NewClient()
+	c.http = &http.Client{Transport: rt}
+	if _, err := c.Search(context.Background(), "ok"); err == nil {
+		t.Fatal("expected timeout error")
+	}
+	res, err := c.Search(context.Background(), "ok")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].Slug != "ok" {
+		t.Fatalf("unexpected result: %+v", res)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func main() {
 	scheduler.Every(1).Hour().Do(func() { handlers.CheckUpdates(ctx, db) })
 	scheduler.StartAsync()
 	pppkg.StartRefresh(ctx)
+	stopJobs := handlers.StartJobQueue(ctx, db)
 
 	r := handlers.New(db, distFS, svc)
 	var shuttingDown atomic.Bool
@@ -133,6 +134,9 @@ func main() {
 		<-ctx.Done()
 		shuttingDown.Store(true)
 		scheduler.Stop()
+		waitCtx, cancelJobs := context.WithTimeout(context.Background(), 5*time.Second)
+		stopJobs(waitCtx)
+		cancelJobs()
 		time.Sleep(200 * time.Millisecond)
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()


### PR DESCRIPTION
## Summary
- identify ModSentinel in Modrinth requests with a User-Agent string and contact URL
- escalate Modrinth client backoff when repeated 429 responses occur and show a rate-limited banner in the instance view
- pool Modrinth HTTP connections with keep-alive and per-host limits to reduce dial churn
- add transport-level connect, TLS handshake, and read timeouts for Modrinth API requests
- retry 5xx and 429 responses with exponential backoff and jitter
- honor Retry-After headers when rate-limited to back off as instructed
- run instance syncs from a background queue so canceled requests don't abort work
- persist sync jobs with statuses and process them in a background worker
- cap concurrent syncs globally and per-instance to avoid thundering herds
- gracefully shut down the sync worker so in-flight jobs finish or are requeued on timeout
- dedupe sync jobs with per-instance idempotency keys to avoid duplicate requests
- normalize Modrinth search queries by trimming, lowercasing, and dropping version suffixes
- resolve project slugs by attempting an exact lookup before falling back to search
- deduplicate concurrent Modrinth requests so identical queries share a single flight
- cache successful Modrinth responses with a short TTL to avoid repeated lookups during a sync
- categorize Modrinth errors as timeout, canceled, rate-limited, server, or client errors
- log Modrinth request metadata (method, URL, status, duration, attempt) while redacting tokens
- emit metrics for Modrinth request outcomes and sync queue depth/active workers
- expose REST endpoints to start, monitor, and cancel background mod sync jobs
- push sync progress updates over Server-Sent Events so instance views receive live job metrics
- render instance sync progress bar with processed/total counts and success/failure tallies
- show last few sync failures with mod name, error, and retry action in instance view
- add Retry failed action to requeue only failed mods for an existing sync job
- persist per-mod sync state (last checked, version, status) to resume syncs after interruptions
- block empty queries and non-ASCII control characters before issuing Modrinth searches
- add unit tests covering retry/backoff, dedupe, caching, and error classification
- add integration tests that stub Modrinth with timeouts, 429s, and 5xxs to assert recovery
- document runbook steps for investigating "context canceled" errors

## Testing
- `go test ./...`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b062420ad883218bbc9c0b1e3d1be6